### PR TITLE
Refactor all responses to be using our custom response helpers

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,14 +1,10 @@
   
 repos:
-    -   repo: https://github.com/pre-commit/mirrors-isort
-        rev: v4.3.21
-        hooks:
-        - id: isort
     -   repo: https://github.com/ambv/black
         rev: stable
         hooks:
         - id: black
-          language_version: python3.8
+          language_version: python3.7
     -   repo: https://github.com/pre-commit/pre-commit-hooks
         rev: v1.2.3
         hooks:

--- a/src/flick/api/urls.py
+++ b/src/flick/api/urls.py
@@ -1,15 +1,14 @@
-from django.urls import include, path
-
-from rest_framework import routers
-
 from asset.views import AssetBundleDetail, AssetBundleList
+from django.urls import include, path
 from flick_auth import urls as auth_urls
 from flick_auth.views import RegisterViewSet
-from friend.views import FriendList
 from item.views import CommentItem, ItemDetail, ItemList, LikeItem
-from show.views import ShowViewSet
+from rest_framework import routers
 from upload.views import UploadImage
 from user.views import UserViewSet
+
+from friend.views import FriendList
+from show.views import SearchShow, ShowViewSet
 
 router = routers.DefaultRouter()
 router.register(r"users", UserViewSet)
@@ -31,4 +30,5 @@ urlpatterns = [
     path("items/<int:pk>/", ItemDetail.as_view(), name="item-detail"),
     path("like/", LikeItem.as_view(), name="like"),
     path("media/image/", UploadImage.as_view(), name="upload"),
+    path("search/", SearchShow.as_view(), name="search-show"),
 ]

--- a/src/flick/api/utils.py
+++ b/src/flick/api/utils.py
@@ -1,0 +1,10 @@
+from rest_framework import generics, mixins, status
+from rest_framework.response import Response
+
+
+def success_response(data, status=status.HTTP_200_OK):
+    return Response({"success": True, "data": data}, status=status)
+
+
+def failure_response(message, status=status.HTTP_404_NOT_FOUND):
+    return Response({"success": False, "error": message}, status=status)

--- a/src/flick/asset/views.py
+++ b/src/flick/asset/views.py
@@ -1,19 +1,20 @@
-from django.http import HttpResponse, JsonResponse
 from django.shortcuts import render
 from django.views.decorators.csrf import csrf_exempt
 
 from rest_framework.parsers import JSONParser
-from rest_framework.response import Response
 from rest_framework import viewsets, status, generics, mixins
 
 from .serializers import AssetBundleSerializer, AssetBundleDetailSerializer
 from .models import AssetBundle
 from api import settings as api_settings
+from api.utils import failure_response, success_response
+
 
 class AssetBundleList(generics.ListCreateAPIView):
     """
     Item: Create, List
     """
+
     queryset = AssetBundle.objects.all()
     serializer_class = AssetBundleSerializer
 
@@ -25,17 +26,18 @@ class AssetBundleList(generics.ListCreateAPIView):
         self.serializer_class = AssetBundleSerializer
         return super(AssetBundleList, self).list(request)
 
+
 class AssetBundleDetail(generics.RetrieveUpdateDestroyAPIView):
     """
     Location: Read, Write, Delete
     """
+
     queryset = AssetBundle.objects.all()
     serializer_class = AssetBundleDetailSerializer
 
     permission_classes = api_settings.CONSUMER_PERMISSIONS
-    
+
     def retrieve(self, request, pk):
         queryset = self.get_object()
         serializer = AssetBundleDetailSerializer(queryset, many=False)
-        return Response(serializer.data)
-
+        return success_response(serializer.data)

--- a/src/flick/flick/settings.py
+++ b/src/flick/flick/settings.py
@@ -15,11 +15,7 @@ from pathlib import Path
 
 from decouple import config
 
-from dotenv import load_dotenv
-
-env_path = Path(".") / ".env"
-load_dotenv(dotenv_path=env_path)
-TMDB_API_KEY = os.getenv("TMDB_API_KEY")
+TMDB_API_KEY = config("TMDB_API_KEY")
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))

--- a/src/flick/flick_auth/views.py
+++ b/src/flick/flick_auth/views.py
@@ -9,6 +9,7 @@ from .utils import AuthTools
 from .serializers import LoginSerializer, UserRegisterSerializer, LoginCompleteSerializer, LogoutSerializer
 from api import settings as api_settings
 from api.generics import CreateAPIView, GenericAPIView, RetrieveUpdateAPIView
+from api.utils import failure_response, success_response
 from user.models import Profile
 from user.serializers import UserSerializer, ProfileSerializer
 
@@ -24,7 +25,7 @@ class UserView(RetrieveUpdateAPIView):
     permission_classes = api_settings.CONSUMER_PERMISSIONS
 
     def get_object(self, *args, **kwargs):
-        return self.request.user
+        return success_response(self.request.user)
 
 
 class ProfileView(RetrieveUpdateAPIView):
@@ -34,7 +35,7 @@ class ProfileView(RetrieveUpdateAPIView):
     permission_classes = api_settings.CONSUMER_PERMISSIONS
 
     def get_object(self, *args, **kwargs):
-        return self.request.user.profile
+        return success_response(self.request.user.profile)
 
 
 class LoginView(GenericAPIView):
@@ -44,9 +45,9 @@ class LoginView(GenericAPIView):
 
     def get(self, request):
         if request.user.is_anonymous:
-            return Response("You are currently not logged in!", status=status.HTTP_200_OK)
+            return success_response("You are currently not logged in!")
         serializer = UserSerializer(request.user)
-        return Response(serializer.data, status=status.HTTP_200_OK)
+        return success_response(serializer.data)
 
     def post(self, request):
         if "username" in request.data and "social_id_token" in request.data:
@@ -58,10 +59,10 @@ class LoginView(GenericAPIView):
             if user is not None:  # and AuthTools.login(request, user):
                 token = AuthTools.issue_user_token(user, "login")
                 serializer = LoginCompleteSerializer(token)
-                return Response(serializer.data)
+                return success_response(serializer.data)
 
-        message = {"error": "Unable to login with the credentials provided."}
-        return Response(message, status=status.HTTP_400_BAD_REQUEST)
+        message = {"Unable to login with the credentials provided."}
+        return failure_response(message)
 
 
 class LogoutView(GenericAPIView):
@@ -70,9 +71,9 @@ class LogoutView(GenericAPIView):
 
     def post(self, request):
         if AuthTools.logout(request):
-            return Response(status=status.HTTP_200_OK)
+            return success_response(None)
 
-        return Response(status=status.HTTP_400_BAD_REQUEST)
+        return failure_response(None)
 
 
 class RegisterView(CreateAPIView):

--- a/src/flick/friend/views.py
+++ b/src/flick/friend/views.py
@@ -1,19 +1,17 @@
+from api import settings as api_settings
 from django.contrib.auth.models import User
 from django.db import IntegrityError
 from django.http import HttpResponse, JsonResponse
 from django.shortcuts import render
 from django.views.decorators.csrf import csrf_exempt
-
-from friend.serializers import FriendUserSerializer
-from friendship.models import Friend, Follow, Block
-
 from rest_framework import generics, mixins, status, viewsets
 from rest_framework.parsers import JSONParser
 from rest_framework.response import Response
+from rest_framework.serializers import CurrentUserDefault, ModelSerializer, PrimaryKeyRelatedField
 from rest_framework.views import APIView
-from rest_framework.serializers import ModelSerializer, PrimaryKeyRelatedField, CurrentUserDefault
 
-from api import settings as api_settings
+from friend.serializers import FriendUserSerializer
+from friendship.models import Block, Follow, Friend
 
 
 class FriendList(APIView):

--- a/src/flick/friend/views.py
+++ b/src/flick/friend/views.py
@@ -13,6 +13,8 @@ from rest_framework.views import APIView
 from friend.serializers import FriendUserSerializer
 from friendship.models import Block, Follow, Friend
 
+from api.utils import failure_response, success_response
+
 
 class FriendList(APIView):
     """
@@ -24,4 +26,4 @@ class FriendList(APIView):
     def get(self, request, format=None):
         friends = [User.objects.get(pk=friend.pk) for friend in Friend.objects.friends(user=request.user)]
         serializer = FriendUserSerializer(friends, many=True)
-        return Response(serializer.data)
+        return success_response(serializer.data)

--- a/src/flick/item/views.py
+++ b/src/flick/item/views.py
@@ -10,6 +10,7 @@ from rest_framework.response import Response
 from .models import Comment, Item, Like
 from .serializers import ItemDetailSerializer, ItemSerializer
 from api import settings as api_settings
+from api.utils import failure_response, success_response
 
 import json
 
@@ -53,7 +54,7 @@ class ItemDetail(generics.RetrieveUpdateDestroyAPIView):
     def retrieve(self, request, pk):
         queryset = self.get_object()
         serializer = ItemDetailSerializer(queryset, many=False)
-        return Response(serializer.data)
+        return success_response(serializer.data)
 
 
 class LikeItem(generics.CreateAPIView):
@@ -61,7 +62,7 @@ class LikeItem(generics.CreateAPIView):
         data = json.loads(request.body)
 
         if "item_id" not in data:
-            return Response({"error": "no item_id in request."}, status=status.HTTP_400_BAD_REQUEST)
+            return failure_response("No item_id in request!")
         item = Item.objects.get(pk=data["item_id"])
 
         try:
@@ -70,10 +71,10 @@ class LikeItem(generics.CreateAPIView):
             like.owner = request.user
             like.save()
         except IntegrityError:
-            return Response({"error": "item already liked by this user!"}, status=status.HTTP_400_BAD_REQUEST)
+            return failure_response("Item already liked by this user!")
 
         serializer = ItemDetailSerializer(item)
-        return Response(serializer.data, status=status.HTTP_200_OK)
+        return success_response(serializer.data)
 
 
 class CommentItem(generics.CreateAPIView):
@@ -81,10 +82,10 @@ class CommentItem(generics.CreateAPIView):
         data = json.loads(request.body)
 
         if "item_id" not in data:
-            return Response({"error": "no item_id in request."}, status=status.HTTP_400_BAD_REQUEST)
+            return failure_response("No item_id in request")
 
         if "body" not in data:
-            return Response({"error": "no body in request."}, status=status.HTTP_400_BAD_REQUEST)
+            return failure_response("No body in request")
         item = Item.objects.get(pk=data["item_id"])
 
         comment = Comment()
@@ -94,4 +95,4 @@ class CommentItem(generics.CreateAPIView):
         comment.save()
 
         serializer = ItemDetailSerializer(item)
-        return Response(serializer.data, status=status.HTTP_200_OK)
+        return success_response(serializer.data)

--- a/src/flick/show/utils.py
+++ b/src/flick/show/utils.py
@@ -3,6 +3,7 @@ import os
 import pprint as pp
 import sys
 
+from django.conf import settings
 from rest_framework import status
 from rest_framework.response import Response
 
@@ -13,7 +14,7 @@ from jikanpy import Jikan
 jikan = Jikan()
 
 # set up the TMDB API access key from .env
-tmdb.API_KEY = os.getenv("TMDB_API_KEY")
+tmdb.API_KEY = settings.TMDB_API_KEY
 
 # Movie data format
 """
@@ -30,14 +31,6 @@ Movie object format
     description: string
 }
 """
-
-
-def success_response(data, status=status.HTTP_200_OK):
-    return Response(json.dumps({"success": True, "data": data}), status=status)
-
-
-def failure_response(message, status=status.HTTP_404_NOT_FOUND):
-    return Response(json.dumps({"success": False, "error": message}), status=status)
 
 
 def get_movie_from_DBinfo(info):
@@ -91,7 +84,7 @@ def get_movie_info(id):
     """
     movie = tmdb.Movies(id)
     try:
-        return json.dumps(get_movie_from_DBinfo(movie.info()))
+        return get_movie_from_DBinfo(movie.info())
     except Exception as e:
         print(e)
         return None
@@ -112,7 +105,7 @@ def get_tv_info(id):
     """
     tv = tmdb.TV(id)
     try:
-        return json.dumps(get_tv_from_DBinfo(tv.info()))
+        return get_tv_from_DBinfo(tv.info())
     except Exception as e:
         print(e)
         return None
@@ -139,7 +132,7 @@ def get_anime_from_DBinfo(info):
 def search_anime(id):
     try:
         search_result = jikan.anime(id)
-        return json.dumps(get_anime_from_DBinfo(search_result))
+        return get_anime_from_DBinfo(search_result)
     except:
         return None
 
@@ -154,9 +147,8 @@ class TMDB_API:
         """
         info = get_movie_info(id)
         if info is not None:
-            return success_response(info)
-        else:
-            return failure_response(f"The movie ID {id} does not exist.")
+            return info
+        return f"The movie ID {id} does not exist."
 
     @staticmethod
     def search_movie_by_name(name):
@@ -167,7 +159,7 @@ class TMDB_API:
         search = tmdb.Search()
         search.movie(query=name)
         media_ids = search_result(search)
-        return success_response(media_ids)
+        return media_ids
 
     @staticmethod
     def get_tv_info_from_id(id):
@@ -176,9 +168,9 @@ class TMDB_API:
         """
         info = get_tv_info(id)
         try:
-            return success_response(info)
+            return info
         except:
-            return failure_response(f"The TV ID {id} does not exist.")
+            return f"The TV ID {id} does not exist."
 
     @staticmethod
     def get_top_movie(page=1):
@@ -192,7 +184,7 @@ class TMDB_API:
             info = get_movie_from_DBinfo(movie_info)
             if info is not None:
                 movies.append(info)
-        return success_response(movies)
+        movies
 
     @staticmethod
     def get_top_tv(page=1):
@@ -206,7 +198,7 @@ class TMDB_API:
             info = get_tv_from_DBinfo(tv_info)
             if info is not None:
                 tvs.append(info)
-        return success_response(tvs)
+        return tvs
 
     @staticmethod
     def search_tv_by_name(name):
@@ -217,7 +209,7 @@ class TMDB_API:
         search = tmdb.Search()
         search.tv(query=name)
         media_ids = search_result(search)
-        return success_response(media_ids)
+        return media_ids
 
     @staticmethod
     # testing function for all info from search
@@ -231,7 +223,7 @@ class TMDB_API:
             info = get_tv_info(movie_id) if is_tv else get_movie_info(movie_id)
             if info is not None:
                 movies.append(info)
-        return success_response(movies)
+        return movies
 
 
 # Anime Data format
@@ -251,7 +243,7 @@ Anime json object
 """
 
 
-class Anim_API:
+class AnimeList_API:
     # Anime helpers
 
     @staticmethod
@@ -262,9 +254,9 @@ class Anim_API:
         """
         info = search_anime(id)
         if info is not None:
-            return success_response(info)
+            return info
         else:
-            return failure_response(f"The anime ID {id} does not exist.")
+            return f"The anime ID {id} does not exist."
 
     @staticmethod
     def search_anime_by_keyword(keyword):
@@ -276,7 +268,7 @@ class Anim_API:
         search_result = jikan.search("anime", keyword, page=1).get("results")
         for anime_info in search_result:
             result.append({"id": anime_info.get("mal_id")})
-        return success_response(result)
+        return result
 
     @staticmethod
     def search_anime_by_year(year, season):
@@ -288,7 +280,7 @@ class Anim_API:
         search_result = jikan.season(year=year, season=season).get("anime")
         for anime_info in search_result:
             result.append({"id": anime_info.get("mal_id")})
-        return success_response(result)
+        return result
 
     @staticmethod
     def get_top_anime():
@@ -300,7 +292,7 @@ class Anim_API:
         search_result = jikan.top(type="anime").get("top")
         for anime_info in search_result:
             result.append({"id": anime_info.get("mal_id")})
-        return success_response(result)
+        return result
 
     @staticmethod
     def anime_info_from_search(search_lst):
@@ -309,4 +301,4 @@ class Anim_API:
             info = search_anime(anime.get("id"))
             if info is not None:
                 animes.append(info)
-        return success_response(animes)
+        return animes

--- a/src/flick/show/views.py
+++ b/src/flick/show/views.py
@@ -1,17 +1,19 @@
+import json
+
+from api import settings as api_settings
+from api.utils import failure_response, success_response
 from django.db import IntegrityError
 from django.http import HttpResponse, JsonResponse
 from django.shortcuts import render
 from django.views.decorators.csrf import csrf_exempt
-
 from rest_framework import generics, mixins, status, viewsets
 from rest_framework.parsers import JSONParser
 from rest_framework.response import Response
+from rest_framework.views import APIView
 
 from .models import Show
 from .serializers import ShowSerializer
-from api import settings as api_settings
-
-import json
+from .utils import TMDB_API, AnimeList_API
 
 
 class ShowViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin, viewsets.GenericViewSet):
@@ -36,3 +38,43 @@ class ShowViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin, viewsets.Gen
     #     queryset = self.get_object()
     #     serializer = ShowDetailSerializer(queryset, many=False)
     #     return Response(serializer.data)
+
+
+class SearchShow(APIView):
+
+    permission_classes = api_settings.UNPROTECTED
+
+    def get(self, request, *args, **kwargs):
+        query = request.query_params.get("query")
+        is_anime = request.query_params.get("is_anime")
+        is_movie = request.query_params.get("is_movie")
+        is_tv = request.query_params.get("is_tv")
+        is_top = request.query_params.get("is_top")
+
+        shows = []
+
+        if is_top:
+            if is_movie:
+                top_movies = TMDB_API.get_top_movie()
+                shows += top_movies if top_movies else []
+            if is_tv:
+                top_shows = TMDB_API.get_top_tv()
+                shows += top_shows if top_shows else []
+            if is_anime:
+                top_anime = AnimeList_API.get_top_anime()
+                shows += top_anime if top_anime else []
+        else:
+            if is_movie:
+                movie_ids = TMDB_API.search_movie_by_name(query)
+                movie_info = [TMDB_API.get_movie_info_from_id(id) for id in movie_ids]
+                shows += movie_info
+            if is_tv:
+                tv_ids = TMDB_API.search_tv_by_name(query)
+                tv_info = [TMDB_API.get_movie_info_from_id(id) for id in tv_ids]
+                shows += tv_info
+            if is_anime:
+                anime_ids = AnimeList_API.search_anime_by_keyword(query)
+                # anime info from search?
+                anime_info = [AnimeList_API.search_anime_by_id(id) for id in anime_ids]
+                shows += anime_info
+        return success_response(shows)

--- a/src/flick/show/views.py
+++ b/src/flick/show/views.py
@@ -37,7 +37,7 @@ class ShowViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin, viewsets.Gen
     # def retrieve(self, request, pk):
     #     queryset = self.get_object()
     #     serializer = ShowDetailSerializer(queryset, many=False)
-    #     return Response(serializer.data)
+    #     return success_response(serializer.data)
 
 
 class SearchShow(APIView):

--- a/src/flick/upload/utils.py
+++ b/src/flick/upload/utils.py
@@ -6,6 +6,7 @@ from rest_framework.serializers import Serializer
 
 from api import settings as api_settings
 from api.generics import generics
+from api.utils import failure_response, success_response
 from asset.models import Asset, AssetBundle
 from flick.tasks import add, resize_and_upload
 from item.models import Item
@@ -29,9 +30,8 @@ def upload_image(image_data, user):
         img_ext = guess_extension(guess_type(image_data)[0])[1:]
 
         if img_ext not in ["jpeg", "jpg", "png", "gif"]:
-            return Response(
-                {"error": "Image type not accepted. Must be jpeg, jpg, png, or gif."},
-                status=status.HTTP_400_BAD_REQUEST,
+            return failure_response(
+                "Image type not accepted. Must be jpeg, jpg, png, or gif.", status=status.HTTP_400_BAD_REQUEST
             )
 
         # remove header of base64 string
@@ -60,4 +60,4 @@ def upload_image(image_data, user):
 
         return asset_bundle
     except Exception as e:
-        return Response({"error": f"{e} REACHES?"}, status=status.HTTP_400_BAD_REQUEST)
+        return failure_response(f"Unable to upload image because of {e}.")


### PR DESCRIPTION
## Overview & Changes Made
Modify all places where we call `Response` from the `rest_framework` library to instead use `success_response` and `failure_response` (and places that we don't even call `Response`!). This is necessary to maintain consistency in the codebase.


## Next Steps
We need to delete all imports of `Response`, `HttpResponse`, etc safely from all files except for the one where the helpers are defined of course. We will also need to get some type of pre-commit hook that checks if you're using a package or not.
Made an issue for this here: #24 


## Related PRs or Issues 
Has changes from #21 since this is where the two custom response helpers are made.
