### PR TITLE
Add update profile

### DIFF
--- a/src/flick/flick_auth/views.py
+++ b/src/flick/flick_auth/views.py
@@ -13,6 +13,7 @@ from api.utils import failure_response, success_response
 from user.models import Profile
 from user.serializers import UserSerializer, ProfileSerializer
 
+import json
 import re
 
 User = get_user_model()
@@ -28,15 +29,42 @@ class UserView(GenericAPIView):
         serializer = ProfileSerializer(profile)
         return success_response(serializer.data)
 
+    def post(self, request):
+        data = json.loads(request.body)
 
-class ProfileView(RetrieveUpdateAPIView):
+        profile = Profile.objects.get(user=self.request.user)
 
-    model = Profile
-    serializer_class = ProfileSerializer
-    permission_classes = api_settings.CONSUMER_PERMISSIONS
+        username = data.get("username")
+        first_name = data.get("first_name")
+        last_name = data.get("last_name")
+        profile_pic_url = data.get("profile_pic")
+        bio = data.get("bio")
+        phone_number = data.get("phone_number")
+        social_id_token_type = data.get("social_id_token_type")
+        social_id_token = data.get("social_id_token")
 
-    def get_object(self, *args, **kwargs):
-        return success_response(self.request.profile)
+        if username and self.request.user.username != username:
+            self.request.user.username = username
+        if first_name and self.request.user.first_name != first_name:
+            self.request.user.first_name = first_name
+        if last_name and self.request.user.last_name != last_name:
+            self.request.user.last_name = last_name
+        if profile_pic_url:
+            profile.profile_pic = profile_pic_url
+        if bio and profile.bio != bio:
+            profile.bio = bio
+        if phone_number and profile.phone_number != phone_number:
+            profile.phone_number = phone_number
+        if social_id_token_type and profile.social_id_token_type != social_id_token_type:
+            profile.social_id_token_type = social_id_token_type
+        if social_id_token and profile.social_id_token != social_id_token:
+            profile.social_id_token = social_id_token
+
+        self.request.user.save()
+        profile.save()
+
+        serializer = ProfileSerializer(profile)
+        return success_response(serializer.data)
 
 
 class LoginView(GenericAPIView):

--- a/src/flick/flick_auth/views.py
+++ b/src/flick/flick_auth/views.py
@@ -37,7 +37,7 @@ class UserView(GenericAPIView):
         username = data.get("username")
         first_name = data.get("first_name")
         last_name = data.get("last_name")
-        profile_pic_url = data.get("profile_pic")
+        profile_pic_base64 = data.get("profile_pic")
         bio = data.get("bio")
         phone_number = data.get("phone_number")
         social_id_token_type = data.get("social_id_token_type")
@@ -49,8 +49,8 @@ class UserView(GenericAPIView):
             self.request.user.first_name = first_name
         if last_name and self.request.user.last_name != last_name:
             self.request.user.last_name = last_name
-        if profile_pic_url:
-            profile.profile_pic = profile_pic_url
+        if profile_pic_base64:
+            profile.profile_pic = profile_pic_base64
         if bio and profile.bio != bio:
             profile.bio = bio
         if phone_number and profile.phone_number != phone_number:

--- a/src/flick/user/models.py
+++ b/src/flick/user/models.py
@@ -26,16 +26,19 @@ class Profile(models.Model):
     def __str__(self):
         return f"{self.user.username}, {self.user.first_name}"
 
-    def save(self, *args, **kwargs):
+    def upload_profile_pic(self):
         from upload.utils import upload_image
 
-        asset_bundle = upload_image(self.profile_pic, self.user)
-        if not asset_bundle:
-            print("Could not upload profile pic")
-        elif not isinstance(asset_bundle, AssetBundle):
-            print(asset_bundle)
+        if self.profile_pic:
+            asset_bundle = upload_image(self.profile_pic, self.user)
+            if not asset_bundle:
+                print("Could not upload profile pic")
+            elif not isinstance(asset_bundle, AssetBundle):
+                print(asset_bundle)
 
-        self.profile_asset_bundle = asset_bundle
-        self.profile_pic = None
-        print(f"asset_bundle: {asset_bundle}")
+            self.profile_asset_bundle = asset_bundle
+            self.profile_pic = None
+
+    def save(self, *args, **kwargs):
+        self.upload_profile_pic()
         super(Profile, self).save(*args, **kwargs)

--- a/src/flick/user/serializers.py
+++ b/src/flick/user/serializers.py
@@ -41,16 +41,23 @@ class UserListSerializer(UserSerializer):
 
 
 class ProfileSerializer(serializers.ModelSerializer):
-    profile_asset_bundle = AssetBundleDetailSerializer(read_only=True)
-    user = UserSerializer(read_only=True)
+    profile_id = serializers.CharField(source="id")
+    user_id = serializers.CharField(source="user.id")
+    first_name = serializers.CharField(source="user.first_name")
+    last_name = serializers.CharField(source="user.last_name")
+    username = serializers.CharField(source="user.username")
+    profile_pic = AssetBundleDetailSerializer(source="profile_asset_bundle")
 
     class Meta:
         model = Profile
         fields = (
-            "id",
-            "user",
+            "user_id",
+            "username",
+            "first_name",
+            "last_name",
+            "profile_id",
+            "profile_pic",
             "bio",
-            "profile_asset_bundle",
             "phone_number",
             "social_id_token_type",
             "social_id_token",


### PR DESCRIPTION
## Overview
Allow users to update their profile with a post to `http://127.0.0.1:8000/api/auth/me/`
This will essentially also serve as a social_id_token refresh endpoint!

## Changes Made
* Add a POST method that allows users to update their profile/user information
* Note that the backend internally keeps track of the user (a Django user) and a profile, so that's why there are two id's (they are matched one-to-one)
* Note the subtle difference that clients will send in a base 64 `profile_pic` string, but we will interpret that as a `profile_pic_base64` in this code and internally in our profile.save(), the backend will just handle the base64 string, parse the image, upload it to AWS, and return a profile_asset_bundle -- but to the clients this just looks like `profile_pic`

## Next Steps 
We will probably have to refactor this bc it's so ugly

## Related PRs or Issues
Closes #15 

## Screenshots
<img width="873" alt="Screen Shot 2020-06-21 at 4 31 17 PM" src="https://user-images.githubusercontent.com/13739525/85237547-a32c7c00-b3dc-11ea-9b32-66279a8579ef.png">
