### PR TITLE
Add tags to lists and lists to tags

### DIFF
--- a/src/flick/lst/models.py
+++ b/src/flick/lst/models.py
@@ -1,9 +1,8 @@
-from asset.models import AssetBundle
-from django.contrib.auth.models import User
-from django.db import models
-
-from show.models import Show
 from user.models import Profile
+
+from django.db import models
+from show.models import Show
+from tag.models import Tag
 
 
 class Lst(models.Model):
@@ -18,8 +17,8 @@ class Lst(models.Model):
     shows = models.ManyToManyField(Show, blank=True)
 
     @property
-    def show_tags(self):
-        pass
+    def tags(self):
+        return Tag.objects.filter(shows__in=self.shows.all())
 
     @property
     def show_titles(self):

--- a/src/flick/lst/serializers.py
+++ b/src/flick/lst/serializers.py
@@ -1,11 +1,10 @@
+from user.profile_simple_serializers import ProfileSimpleSerializer
+
 from rest_framework import serializers
+from show.serializers import ShowSerializer
+from tag.simple_serializers import TagSimpleSerializer
 
 from .models import Lst
-from asset.serializers import AssetBundleDetailSerializer
-from show.simple_serializers import ShowSimpleSerializer
-from show.serializers import ShowSerializer
-from tag.serializers import TagSerializer
-from user.profile_simple_serializers import ProfileSimpleSerializer
 
 
 class LstSerializer(serializers.ModelSerializer):
@@ -13,6 +12,7 @@ class LstSerializer(serializers.ModelSerializer):
     owner = ProfileSimpleSerializer(many=False)
     shows = ShowSerializer(many=True)
     lst_id = serializers.CharField(source="id")
+    tags = TagSimpleSerializer(many=True)
 
     class Meta:
         model = Lst
@@ -26,5 +26,6 @@ class LstSerializer(serializers.ModelSerializer):
             "collaborators",
             "owner",
             "shows",
+            "tags",
         )
         read_only_fields = fields

--- a/src/flick/lst/simple_serializers.py
+++ b/src/flick/lst/simple_serializers.py
@@ -1,17 +1,13 @@
 from rest_framework import serializers
 
 from .models import Lst
-from asset.serializers import AssetBundleDetailSerializer
-from show.simple_serializers import ShowSimpleSerializer
-from show.serializers import ShowSerializer
-from tag.serializers import TagSerializer
 
 
 class LstSimpleSerializer(serializers.ModelSerializer):
-    shows = ShowSerializer(many=True)
+    # shows = ShowSerializer(many=True)
     lst_id = serializers.CharField(source="id")
 
     class Meta:
         model = Lst
-        fields = ("lst_id", "lst_name", "lst_pic", "is_saved", "is_private", "is_watch_later", "shows")
+        fields = ("lst_id", "lst_name", "lst_pic", "is_saved", "is_private", "is_watch_later")
         read_only_fields = fields

--- a/src/flick/show/serializers.py
+++ b/src/flick/show/serializers.py
@@ -1,15 +1,12 @@
-from django.contrib.auth.models import User
-
-from rest_framework.serializers import CurrentUserDefault, ModelSerializer, PrimaryKeyRelatedField
+from rest_framework.serializers import ModelSerializer
+from tag.simple_serializers import TagSimpleSerializer
 
 from .models import Show
-from asset.serializers import AssetBundleDetailSerializer
-from tag.serializers import TagSerializer
 
 
 class ShowSerializer(ModelSerializer):
     # CurrentUserDefault is basically request.data (the authenticated user related to this request)
-    tags = TagSerializer(read_only=True, many=True)
+    tags = TagSimpleSerializer(read_only=True, many=True)
 
     class Meta:
         model = Show

--- a/src/flick/tag/models.py
+++ b/src/flick/tag/models.py
@@ -3,17 +3,15 @@ from django.db import models
 
 class Tag(models.Model):
     tag = models.CharField(max_length=100, unique=True)
-    # shows = models.ManyToManyField(Show, blank=True)
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
 
     @property
-    def shows(self, obj):
-        res = []
-        print(obj.shows.all())
-        for show in obj.shows.all():
-            print(f"show: {show}")
-            print(f"show.title: {show.title}")
-            res += show.title
-        print(f"res: {res}")
-        return res
+    def shows(self):
+        return [show.title for show in self.shows.all()]
+
+    @property
+    def lsts(self):
+        from lst.models import Lst
+
+        return Lst.objects.filter(shows__in=self.shows.all())

--- a/src/flick/tag/serializers.py
+++ b/src/flick/tag/serializers.py
@@ -1,24 +1,16 @@
+from lst.simple_serializers import LstSimpleSerializer
 from rest_framework import serializers
+from show.simple_serializers import ShowSimpleSerializer
 
 from .models import Tag
-
-from show.simple_serializers import ShowSimpleSerializer
 
 
 class TagSerializer(serializers.ModelSerializer):
     tag_id = serializers.CharField(source="id")
-
-    class Meta:
-        model = Tag
-        fields = ("tag_id", "tag")
-        read_only_fields = fields
-
-
-class TagDetailSerializer(serializers.ModelSerializer):
-    tag_id = serializers.CharField(source="id")
     shows = ShowSimpleSerializer(many=True, read_only=True)
+    lsts = LstSimpleSerializer(many=True, read_only=True)
 
     class Meta:
         model = Tag
-        fields = ("tag_id", "tag", "shows")
+        fields = ("tag_id", "tag", "shows", "lsts")
         read_only_fields = fields

--- a/src/flick/tag/simple_serializers.py
+++ b/src/flick/tag/simple_serializers.py
@@ -1,0 +1,12 @@
+from rest_framework import serializers
+
+from .models import Tag
+
+
+class TagSimpleSerializer(serializers.ModelSerializer):
+    tag_id = serializers.CharField(source="id")
+
+    class Meta:
+        model = Tag
+        fields = ("tag_id", "tag")
+        read_only_fields = fields

--- a/src/flick/tag/views.py
+++ b/src/flick/tag/views.py
@@ -1,18 +1,9 @@
-from django.db import IntegrityError
-from django.http import HttpResponse, JsonResponse
-from django.shortcuts import render
-from django.views.decorators.csrf import csrf_exempt
-
-from rest_framework import generics, mixins, status, viewsets
-from rest_framework.parsers import JSONParser
-from rest_framework.response import Response
+from api import settings as api_settings
+from api.utils import success_response
+from rest_framework import generics
 
 from .models import Tag
-from .serializers import TagDetailSerializer, TagSerializer
-from api import settings as api_settings
-from api.utils import failure_response, success_response
-
-import json
+from .serializers import TagSerializer
 
 
 class TagList(generics.ListCreateAPIView):
@@ -21,7 +12,7 @@ class TagList(generics.ListCreateAPIView):
     """
 
     queryset = Tag.objects.all()
-    serializer_class = TagDetailSerializer
+    serializer_class = TagSerializer
 
     # if api_settings.UNPROTECTED, then any user can see this
     permission_classes = api_settings.UNPROTECTED
@@ -47,11 +38,11 @@ class TagDetail(generics.RetrieveUpdateDestroyAPIView):
     """
 
     queryset = Tag.objects.all()
-    serializer_class = TagDetailSerializer
+    serializer_class = TagSerializer
 
     permission_classes = api_settings.UNPROTECTED
 
     def retrieve(self, request, pk):
         queryset = self.get_object()
-        serializer = TagDetailSerializer(queryset, many=False)
+        serializer = TagSerializer(queryset, many=False)
         return success_response(serializer.data)


### PR DESCRIPTION
## Overview
* You can now see all tags in a list (GET http://127.0.0.1:8000/api/lsts/ or http://127.0.0.1:8000/api/lsts/<id>)
[lst_results.txt](https://github.com/flickchicks/flick-backend/files/4907780/lst_results.txt)

* You can also see all lists for tags (GET http://127.0.0.1:8000/api/tags/ or http://127.0.0.1:8000/api/tags/<id>/)
[tags_results.txt](https://github.com/flickchicks/flick-backend/files/4907779/tags_results.txt)

## Test Coverage
Tested locally



## Next Steps
Follow up with @haiyingweng if she still wants the full list view when you look at the tags
@olivialy524 ensure that `api/search/` also returns lists in tag view


## Related PRs or Issues
Closes #70 
Closes #36 
