### PR TITLE
Add more default list restrictions on delete

### DIFF
--- a/src/flick/lst/controllers/delete_lst_controller.py
+++ b/src/flick/lst/controllers/delete_lst_controller.py
@@ -1,0 +1,25 @@
+from user.models import Profile
+
+from api.utils import failure_response
+from api.utils import success_response
+from lst.models import Lst
+
+
+class DeleteLstController:
+    def __init__(self, request, pk):
+        self._request = request
+        self._pk = pk
+
+    def process(self):
+        if not Lst.objects.filter(pk=self._pk):
+            return failure_response(f"List of id {self._pk} does not exist.")
+        lst = Lst.objects.get(pk=self._pk)
+        if lst.is_saved:
+            return failure_response(f"This list is a default saved list and cannot be deleted.")
+        if lst.is_watch_later:
+            return failure_response(f"This list is a default watch later list and cannot be deleted.")
+        profile = Profile.objects.get(user=self._request.user)
+        if not profile == lst.owner:
+            return failure_response(f"User of id {self._request.user.id} is not the owner of list of id {self._pk}.")
+        lst.delete()
+        return success_response(f"List of id {self._pk} has been deleted.")

--- a/src/flick/lst/views.py
+++ b/src/flick/lst/views.py
@@ -8,6 +8,7 @@ from django.db.models import Q
 from rest_framework import generics
 
 from .controllers.create_lst_controller import CreateLstController
+from .controllers.delete_lst_controller import DeleteLstController
 from .controllers.update_lst_controller import UpdateLstController
 from .models import Lst
 from .serializers import LstSerializer
@@ -69,14 +70,7 @@ class LstDetail(generics.GenericAPIView):
         Delete a list by id.
         Only owners of lists can delete their lists.
         """
-        if not Lst.objects.filter(pk=pk):
-            return failure_response(f"List of id {pk} does not exist.")
-        lst = Lst.objects.get(pk=pk)
-        profile = Profile.objects.get(user=request.user)
-        if not profile == lst.owner:
-            return failure_response(f"User of id {request.user.id} is not the owner of list of id {pk}.")
-        lst.delete()
-        return success_response(f"List of id {pk} has been deleted.")
+        return DeleteLstController(request, pk).process()
 
     def post(self, request, pk):
         """


### PR DESCRIPTION
## Overview
Regardless of if you are an owner, you cannot delete your own `is_saved` and `is_watch_later` lists, as these are default lists.


## Related PRs or Issues
Closes #78 



## Example Error
```
{
    "success": false,
    "error": "This list is a default watch later list and cannot be deleted."
}
```