### PR TITLE
Add num notifs at me endpoint

### DIFF
--- a/src/flick/flick_auth/tests/test_me.py
+++ b/src/flick/flick_auth/tests/test_me.py
@@ -47,5 +47,6 @@ class MeTests(TestCase):
         self.assertEqual(content.get("username"), "AlannaZhou")
         self.assertEqual(content.get("first_name"), "Alanna")
         self.assertEqual(content.get("last_name"), "Zhou")
+        self.assertEqual(content.get("num_notifs"), 0)
         self.assertEqual(len(content.get("owner_lsts")), 2)
         self.assertEqual(len(content.get("collab_lsts")), 0)

--- a/src/flick/flick_auth/views.py
+++ b/src/flick/flick_auth/views.py
@@ -24,7 +24,7 @@ class UserView(generics.GenericAPIView):
 
     def get(self, request):
         profile = Profile.objects.get(user=self.request.user)
-        serializer = ProfileSerializer(profile)
+        serializer = self.serializer_class(profile)
         return success_response(serializer.data)
 
     def post(self, request):

--- a/src/flick/notification/tests/test_list_invite_notification.py
+++ b/src/flick/notification/tests/test_list_invite_notification.py
@@ -64,17 +64,16 @@ class ListInviteNotificationTests(TestCase):
         self._send_friend_requests()
         self._accept_user_friend_requests(self.friend_token)
 
-    def _create_list(self, id=5):
+    def _create_list(self):
         self.client.credentials(HTTP_AUTHORIZATION="Token " + self.user_token)
         request_data = {"name": "Alanna's Kdramas", "collaborators": [2], "shows": [], "tags": []}
         response = self.client.post(self.CREATE_LST_URL, request_data, format="json")
         self.assertEqual(response.status_code, 200)
         data = json.loads(response.content)["data"]
         # each user gets 2 default lists, additional one will have id of 5
-        self.assertEqual(data["id"], id)
+        self.assertEqual(data["id"], 5)
         self.assertEqual(data["collaborators"][0]["id"], 2)
         self.assertEqual(data["owner"]["id"], 1)
-        return data["id"]
 
     def _create_and_update_list(self):
         self.client.credentials(HTTP_AUTHORIZATION="Token " + self.user_token)

--- a/src/flick/suggestion/models.py
+++ b/src/flick/suggestion/models.py
@@ -15,7 +15,7 @@ class PublicSuggestion(models.Model):
 class PrivateSuggestion(models.Model):
     to_user = models.ForeignKey(User, related_name="suggestions_received", on_delete=models.CASCADE)
     from_user = models.ForeignKey(Profile, related_name="suggestions_sent", on_delete=models.CASCADE)
-    message = models.CharField(max_length=140, blank=True)
+    message = models.CharField(max_length=140, blank=True, null=True)
     show = models.ForeignKey(Show, related_name="suggestion", blank=False, on_delete=models.CASCADE)
     created_at = models.DateTimeField(auto_now=True)
 

--- a/src/flick/suggestion/views.py
+++ b/src/flick/suggestion/views.py
@@ -32,7 +32,7 @@ class PrivateSuggestionView(generics.GenericAPIView):
         show_id = data.get("show_id")
         if not Show.objects.filter(id=show_id):
             return failure_response(f"Show of id {show_id} does not exist.")
-        show = Show.objects.get(id=data.get("show_id"))
+        show = Show.objects.get(id=show_id)
 
         suggestions = []
         for friend_id in data.get("users"):
@@ -48,8 +48,7 @@ class PrivateSuggestionView(generics.GenericAPIView):
                 pri_suggestion.from_user = profile
                 pri_suggestion.to_user = friend
                 pri_suggestion.show = show
-                if data.get("message"):
-                    pri_suggestion.message = data.get("message")
+                pri_suggestion.message = data.get("message")
                 pri_suggestion.save()
                 suggestions.append(pri_suggestion)
             except Exception as e:

--- a/src/flick/user/models.py
+++ b/src/flick/user/models.py
@@ -21,6 +21,12 @@ class Profile(models.Model):
     def __str__(self):
         return f"{self.user.username}, {self.user.first_name}"
 
+    @property
+    def num_notifs(self):
+        from notification.models import Notification
+
+        return Notification.objects.filter(to_user=self).count()
+
     def upload_profile_pic(self):
         from upload.utils import upload_image
 

--- a/src/flick/user/serializers.py
+++ b/src/flick/user/serializers.py
@@ -41,8 +41,8 @@ class ProfileSerializer(serializers.ModelSerializer):
     last_name = serializers.CharField(source="user.last_name")
     username = serializers.CharField(source="user.username")
     profile_pic = AssetBundleDetailSerializer(source="profile_asset_bundle")
-    owner_lsts = MeLstSerializer(read_only=True, many=True)
-    collab_lsts = MeLstSerializer(read_only=True, many=True)
+    owner_lsts = MeLstSerializer(many=True)
+    collab_lsts = MeLstSerializer(many=True)
 
     class Meta:
         model = Profile
@@ -56,6 +56,7 @@ class ProfileSerializer(serializers.ModelSerializer):
             "phone_number",
             "social_id_token_type",
             "social_id_token",
+            "num_notifs",
             "owner_lsts",
             "collab_lsts",
         )


### PR DESCRIPTION
## Overview
* Return notif count as `num_notifs` at the `api/auth/me` endpoint
* Refactor suggestions a bit along the way @olivialy524 make sure you address PR comments before merging! I'll be requesting changes next time 😆 

## Test Coverage
All tests and modified ones pass
```
----------------------------------------------------------------------
Ran 24 tests in 11.117s

OK
Destroying test database for alias 'default'...

10 slowest tests:
0.7794s test_friends_rating (show.tests.test_show_rating_comment.ShowRatingsAndCommentTests)
0.7753s test_suggestions (suggestion.tests.PrivateSuggestionTests)
0.7734s test_friends_comments (show.tests.test_show_rating_comment.ShowRatingsAndCommentTests)
0.7508s test_user_can_comment_show (show.tests.test_show_rating_comment.ShowRatingsAndCommentTests)
0.7283s test_user_can_rate_show (show.tests.test_show_rating_comment.ShowRatingsAndCommentTests)
0.6743s test_search_show (search.tests.test_search_shows.SearchShowsTests)
0.5971s test_accept_incoming_friend_request (friend.tests.test_friendship.FriendshipTests)
0.5418s test_add_and_remove_from_lst (lst.tests.test_update_lst.UpdateLstTests)
0.5287s test_shows_removed_from_lst_edit_notification (lst.tests.test_update_lst.UpdateLstTests)
0.5237s test_list_invite_via_list_update (notification.tests.test_list_invite_notification.ListInviteNotificationTests)
```

## Related PRs or Issues
Closes #88 