### PR TITLE
Show number of mutual friends when searching for users

### DIFF
--- a/src/flick/notification/tests/test_list_invite_notification.py
+++ b/src/flick/notification/tests/test_list_invite_notification.py
@@ -2,16 +2,16 @@ import json
 import random
 import string
 
+from django.contrib.auth.models import User
 from django.test import TestCase
 from django.urls import reverse
+from friendship.models import Friend
 from rest_framework.test import APIClient
 
 
 class ListInviteNotificationTests(TestCase):
     REGISTER_URL = reverse("register")
     LOGIN_URL = reverse("login")
-    FRIEND_REQUEST_URL = reverse("friend-request")
-    FRIEND_ACCEPT_URL = reverse("friend-accept")
     CREATE_LST_URL = reverse("lst-list")
     NOTIFICATIONS_URL = reverse("notif-list")
     UPDATE_LST_URL = reverse("lst-detail", kwargs={"pk": 5})
@@ -20,7 +20,7 @@ class ListInviteNotificationTests(TestCase):
         self.client = APIClient()
         self.user_token = self._create_user_and_login()
         self.friend_token = self._create_user_and_login()
-        self._add_friends()
+        self._create_friendship(user1=User.objects.get(id=1), user2=User.objects.get(id=2))
 
     def _create_user_and_login(self):
         """Returns the auth token."""
@@ -44,24 +44,8 @@ class ListInviteNotificationTests(TestCase):
         token = json.loads(response.content)["data"]["auth_token"]
         return token
 
-    def _send_friend_requests(self):
-        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.user_token)
-        request_data = {"ids": [2]}
-        response = self.client.post(self.FRIEND_REQUEST_URL, request_data, format="json")
-        data = json.loads(response.content)["data"]
-        self.assertEqual(len(data), 1)
-        self.assertEqual(data[0]["to_user"]["id"], 2)
-
-    def _accept_user_friend_requests(self, token):
-        self.client.credentials(HTTP_AUTHORIZATION="Token " + token)
-        request_data = {"ids": [1]}
-        response = self.client.post(self.FRIEND_ACCEPT_URL, request_data, format="json")
-        data = json.loads(response.content)["data"]
-        self.assertEqual(data[0]["from_user"]["id"], 1)
-
-    def _add_friends(self):
-        self._send_friend_requests()
-        self._accept_user_friend_requests(self.friend_token)
+    def _create_friendship(self, user1, user2):
+        Friend.objects.add_friend(user1, user2).accept()
 
     def _create_list(self):
         self.client.credentials(HTTP_AUTHORIZATION="Token " + self.user_token)

--- a/src/flick/search/tests/test_search_users.py
+++ b/src/flick/search/tests/test_search_users.py
@@ -1,0 +1,69 @@
+import json
+import random
+import string
+
+from django.contrib.auth.models import User
+from django.test import TestCase
+from django.urls import reverse
+from friendship.models import Friend
+from rest_framework.test import APIClient
+
+
+class SearchUsersTests(TestCase):
+    REGISTER_URL = reverse("register")
+    LOGIN_URL = reverse("login")
+    SEARCH_URL = reverse("search")
+
+    def setUp(self):
+        self.client = APIClient()
+        self.user_token = self._create_user_and_login()
+        self.friend1_token = self._create_user_and_login()
+        self.friend2_token = self._create_user_and_login()
+        self.friend3_token = self._create_user_and_login()
+        self.user = User.objects.get(id=1)
+        self.friend1 = User.objects.get(id=2)
+        self.friend2 = User.objects.get(id=3)
+        self.friend3 = User.objects.get(id=4)
+        # user and friend3 should have one mutual friend: friend1
+        self._create_friendship(user1=self.user, user2=self.friend1)
+        self._create_friendship(user1=self.user, user2=self.friend2)
+        self._create_friendship(user1=self.friend3, user2=self.friend1)
+
+    def _create_user_and_login(self):
+        """Returns the auth token."""
+        letters = string.digits
+        random_string = "".join(random.choice(letters) for i in range(10))
+        register_data = {
+            "username": "",
+            "first_name": "Alanna",
+            "last_name": "Zhou",
+            "profile_pic": "",
+            "social_id_token": random_string,
+            "social_id_token_type": "test",
+        }
+        response = self.client.post(self.REGISTER_URL, register_data)
+        self.assertEqual(response.status_code, 200)
+        username = json.loads(response.content)["data"]["username"]
+
+        login_data = {"username": username, "social_id_token": random_string}
+        response = self.client.post(self.LOGIN_URL, login_data)
+        self.assertEqual(response.status_code, 200)
+        token = json.loads(response.content)["data"]["auth_token"]
+        return token
+
+    def _create_friendship(self, user1, user2):
+        Friend.objects.add_friend(user1, user2).accept()
+
+    def test_search_user(self):
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.user_token)
+        data = {"is_user": True, "query": self.friend3.username}
+        response = self.client.get(self.SEARCH_URL, data, format="json")
+        content = json.loads(response.content)
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(content.get("success"))
+        data = content.get("data")[0]
+        self.assertEqual(data["id"], self.friend3.id)
+        self.assertEqual(data["username"], self.friend3.username)
+        self.assertEqual(data["first_name"], self.friend3.first_name)
+        self.assertEqual(data["last_name"], self.friend3.last_name)
+        self.assertEqual(data["num_mutual_friends"], 1)

--- a/src/flick/search/views.py
+++ b/src/flick/search/views.py
@@ -59,7 +59,6 @@ class Search(APIView):
 
     def get_users_by_username(self, query):
         users = User.objects.filter(username__icontains=query)
-        # context={"request": self.request},
         serializer = UserSimpleSerializer(instance=users, many=True, context={"request": self.request})
         return serializer.data
 

--- a/src/flick/search/views.py
+++ b/src/flick/search/views.py
@@ -59,7 +59,8 @@ class Search(APIView):
 
     def get_users_by_username(self, query):
         users = User.objects.filter(username__icontains=query)
-        serializer = UserSimpleSerializer(users, many=True)
+        # context={"request": self.request},
+        serializer = UserSimpleSerializer(instance=users, many=True, context={"request": self.request})
         return serializer.data
 
     def get_lsts_by_name(self, query):

--- a/src/flick/show/tests/test_show_rating_comment.py
+++ b/src/flick/show/tests/test_show_rating_comment.py
@@ -2,8 +2,11 @@ import json
 import random
 import string
 
+from django.contrib.auth.models import User
 from django.test import TestCase
 from django.urls import reverse
+from friendship.exceptions import AlreadyFriendsError
+from friendship.models import Friend
 from rest_framework.test import APIClient
 from show.models import Show
 
@@ -11,8 +14,6 @@ from show.models import Show
 class ShowRatingsAndCommentTests(TestCase):
     REGISTER_URL = reverse("register")
     LOGIN_URL = reverse("login")
-    FRIEND_REQUEST_URL = reverse("friend-request")
-    FRIEND_ACCEPT_URL = reverse("friend-accept")
 
     def setUp(self):
         self.client = APIClient()
@@ -87,25 +88,15 @@ class ShowRatingsAndCommentTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(comment["message"], comment_data.get("comment").get("message"))
 
-    def _send_friend_requests(self):
-        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.user_token)
-        request_data = {"ids": [2, 3]}
-        response = self.client.post(self.FRIEND_REQUEST_URL, request_data, format="json")
-        json.loads(response.content)["data"]
-
-    def _accept_user_friend_requests(self, token):
-        self.client.credentials(HTTP_AUTHORIZATION="Token " + token)
-        request_data = {"ids": [1]}
-        response = self.client.post(self.FRIEND_ACCEPT_URL, request_data, format="json")
-        json.loads(response.content)["data"]
-
-    def _add_friends(self):
-        self._send_friend_requests()
-        self._accept_user_friend_requests(self.friend1_token)
-        self._accept_user_friend_requests(self.friend2_token)
+    def _create_friendship(self, user1, user2):
+        try:
+            Friend.objects.add_friend(user1, user2).accept()
+        except AlreadyFriendsError:
+            return
 
     def _check_friends_rating(self, rating):
-        self._add_friends()
+        self._create_friendship(user1=User.objects.get(id=1), user2=User.objects.get(id=2))
+        self._create_friendship(user1=User.objects.get(id=1), user2=User.objects.get(id=3))
         self.client.credentials(HTTP_AUTHORIZATION="Token " + self.user_token)
         response = self.client.get(self.SHOW_DETAIL_URL)
         content = json.loads(response.content)

--- a/src/flick/user/user_simple_serializers.py
+++ b/src/flick/user/user_simple_serializers.py
@@ -1,12 +1,23 @@
 from asset.serializers import AssetBundleDetailSerializer
 from django.contrib.auth.models import User
+from friendship.models import Friend
 from rest_framework import serializers
 
 
 class UserSimpleSerializer(serializers.ModelSerializer):
     profile_pic = AssetBundleDetailSerializer(source="profile.profile_asset_bundle")
+    num_mutual_friends = serializers.SerializerMethodField(method_name="get_num_mutual_friends")
 
     class Meta:
         model = User
-        fields = ("id", "username", "first_name", "last_name", "profile_pic")
+        fields = ("id", "username", "first_name", "last_name", "profile_pic", "num_mutual_friends")
         read_only_fields = fields
+
+    def get_num_mutual_friends(self, instance):
+        if not self.context:
+            return None
+        request = self.context.get("request")
+        request_user_friends = Friend.objects.friends(request.user)
+        searched_user_friends = Friend.objects.friends(instance)
+        mutual_friends = list(set(request_user_friends) & set(searched_user_friends))
+        return len(mutual_friends)

--- a/src/flick/user/user_simple_serializers.py
+++ b/src/flick/user/user_simple_serializers.py
@@ -14,7 +14,7 @@ class UserSimpleSerializer(serializers.ModelSerializer):
         read_only_fields = fields
 
     def get_num_mutual_friends(self, instance):
-        if not self.context:
+        if not self.context or not self.context.get("request"):
             return None
         request = self.context.get("request")
         request_user_friends = Friend.objects.friends(request.user)


### PR DESCRIPTION
## Overview
* Add mutual friend count when we return the list of users for each user
* Refactor tests that involve friendships

Here's what we'll return once you search up a user for example:
```
[{'id': 4, 'username': 'AlannaZhou3', 'first_name': 'Alanna', 'last_name': 'Zhou', 'profile_pic': None, 'num_mutual_friends': 1}]
```


## Test Coverage
All tests pass (and no more of those weird print statements!)
```
(venv) ~/D/f/s/flick ❯❯❯ ./manage.py test
Creating test database for alias 'default'...
System check identified no issues (0 silenced).
.........................
----------------------------------------------------------------------
Ran 25 tests in 12.407s

OK
Destroying test database for alias 'default'...

10 slowest tests:
0.9771s test_search_user (search.tests.test_search_users.SearchUsersTests)
0.8226s test_suggestions (suggestion.tests.PrivateSuggestionTests)
0.8207s test_user_can_comment_show (show.tests.test_show_rating_comment.ShowRatingsAndCommentTests)
0.8202s test_friends_rating (show.tests.test_show_rating_comment.ShowRatingsAndCommentTests)
0.7747s test_friends_comments (show.tests.test_show_rating_comment.ShowRatingsAndCommentTests)
0.7676s test_user_can_rate_show (show.tests.test_show_rating_comment.ShowRatingsAndCommentTests)
0.6006s test_add_and_remove_from_lst (lst.tests.test_update_lst.UpdateLstTests)
0.5926s test_shows_removed_from_lst_edit_notification (lst.tests.test_update_lst.UpdateLstTests)
0.5773s test_shows_added_to_lst_edit_notification (lst.tests.test_update_lst.UpdateLstTests)
0.5698s test_update_lst (lst.tests.test_update_lst.UpdateLstTests)
```


## Next Steps 
Found that notifications aren't being ordered, should probably do that #120 

## Related PRs or Issues
Closes #77 