### PR TITLE
Add # of suggestions to # notifs at /me

### DIFF
--- a/src/flick/user/models.py
+++ b/src/flick/user/models.py
@@ -25,10 +25,14 @@ class Profile(models.Model):
     @property
     def num_notifs(self):
         from notification.models import Notification
+        from suggestion.models import PrivateSuggestion
 
-        return Notification.objects.filter(
-            Q(to_user=self) & ~(Q(notif_type="friend_request") & Q(friend_request_accepted=False))
-        ).count()
+        return (
+            Notification.objects.filter(
+                Q(to_user=self) & ~(Q(notif_type="friend_request") & Q(friend_request_accepted=False))
+            ).count()
+            + PrivateSuggestion.objects.filter(to_user=self.user).count()
+        )
 
     def upload_profile_pic(self):
         from upload.utils import upload_image


### PR DESCRIPTION
## Overview
Right now we only count the number of notifications at `/api/auth/me`'s `num_notifs`, but we need to include the number of suggestions as well!



## Changes Made
Add count and update tests


## Test Coverage
```
(venv) ~/D/f/s/flick ❯❯❯ ./manage.py test                                                                            ✘ 1 
Creating test database for alias 'default'...
System check identified no issues (0 silenced).
..........................
----------------------------------------------------------------------
Ran 26 tests in 12.754s

OK
Destroying test database for alias 'default'...
```




## Next Steps
@olivialy524 should update `PrivateSuggestion`'s `to_user` to be `Profile` instead of `User`!



## Related PRs or Issues
Closes #121 
Closes #142 