### PR TITLE
Add search tags by name

### DIFF
--- a/src/flick/search/tests/test_search_tags.py
+++ b/src/flick/search/tests/test_search_tags.py
@@ -1,0 +1,55 @@
+import json
+import random
+import string
+
+from django.test import TestCase
+from django.urls import reverse
+from rest_framework.test import APIClient
+from tag.models import Tag
+
+
+class SearchTagsTests(TestCase):
+    REGISTER_URL = reverse("register")
+    LOGIN_URL = reverse("login")
+    SEARCH_URL = reverse("search")
+
+    def setUp(self):
+        self.client = APIClient()
+        self.user_token = self._create_user_and_login()
+
+    def _create_user_and_login(self):
+        """Returns the auth token."""
+        letters = string.digits
+        random_string = "".join(random.choice(letters) for i in range(10))
+        register_data = {
+            "username": "",
+            "first_name": "Alanna",
+            "last_name": "Zhou",
+            "profile_pic": "",
+            "social_id_token": random_string,
+            "social_id_token_type": "test",
+        }
+        response = self.client.post(self.REGISTER_URL, register_data)
+        self.assertEqual(response.status_code, 200)
+        username = json.loads(response.content)["data"]["username"]
+
+        login_data = {"username": username, "social_id_token": random_string}
+        response = self.client.post(self.LOGIN_URL, login_data)
+        self.assertEqual(response.status_code, 200)
+        token = json.loads(response.content)["data"]["auth_token"]
+        return token
+
+    def test_search_tag(self):
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.user_token)
+        Tag.objects.create(name="amazing")
+        Tag.objects.create(name="hhhhh")
+        Tag.objects.create(name="Another")
+        data = {"is_tag": True, "query": "a"}
+        response = self.client.get(self.SEARCH_URL, data, format="json")
+        content = json.loads(response.content)
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(content.get("success"))
+        data = content.get("data")
+        self.assertEqual(len(data), 2)
+        self.assertEqual(data[0]["name"], "amazing")
+        self.assertEqual(data[1]["name"], "Another")

--- a/src/flick/search/views.py
+++ b/src/flick/search/views.py
@@ -11,6 +11,7 @@ from show.models import Show
 from show.serializers import ShowSerializer
 from show.show_api_utils import ShowAPI
 from tag.models import Tag
+from tag.simple_serializers import TagSimpleSerializer
 
 # cache to store search_movie_by_name (and tv and anime)
 # search_movie_by_name example: ("query", "movie"), movie_id
@@ -67,6 +68,10 @@ class Search(APIView):
         serializer = LstSerializer(lsts, many=True)
         return serializer.data
 
+    def get_tags_by_name(self, query):
+        tags = Tag.objects.filter(name__icontains=query)
+        return TagSimpleSerializer(tags, many=True).data
+
     def get(self, request, *args, **kwargs):
         self.request = request
         query = request.query_params.get("query")
@@ -76,6 +81,7 @@ class Search(APIView):
         is_tv = bool(request.query_params.get("is_tv", False))
         is_user = bool(request.query_params.get("is_user", False))
         is_lst = bool(request.query_params.get("is_lst", False))
+        is_tag = bool(request.query_params.get("is_tag", False))
 
         self.shows = []
         self.known_shows = []
@@ -84,6 +90,8 @@ class Search(APIView):
             return success_response(self.get_users_by_username(query))
         elif is_lst:
             return success_response(self.get_lsts_by_name(query))
+        elif is_tag:
+            return success_response(self.get_tags_by_name(query))
         else:
             self.get_shows_by_query(query, is_movie, is_tv, is_anime, tags)
 


### PR DESCRIPTION
## Overview
Currently our search endpoint handles everything (shows, lists, users, top shows) except for tags
@haiyingweng should lmk if the tags should be more detailed, but an example request looks like the following~
## **POST http://127.0.0.1:8000/api/search/?is_tag=True&query=a**
Note: there's a custom tag that I created called "alanna" lol but basically users can create their custom tags (which is what the frontend should be doing before users add a custom tag to a list)
```
{
    "success": true,
    "data": [
        {
            "id": 2,
            "name": "Drama"
        },
        {
            "id": 3,
            "name": "Romance"
        },
        {
            "id": 7,
            "name": "Documentary"
        },
        {
            "id": 8,
            "name": "Animation"
        },
        {
            "id": 18,
            "name": "alanna"
        },
    ]
}
```


## Changes Made
* Add a case insensitive search for tags by their names
* Return the tag names and IDs
* Add a simple test


## Test Coverage
All tests pass
```
----------------------------------------------------------------------
Ran 27 tests in 12.733s

OK
```

## Related PRs or Issues
Closes #153 

