### PR TITLE
Remove modifying list type fields for update lst

### DIFF
--- a/src/flick/lst/controllers/update_lst_controller.py
+++ b/src/flick/lst/controllers/update_lst_controller.py
@@ -23,7 +23,7 @@ class UpdateLstController:
         self._is_add = is_add
         self._is_remove = is_remove
 
-    def _should_clear(self):
+    def _is_simple_update(self):
         return not (self._is_add or self._is_remove)
 
     def _notify_collaborator(self, profile):
@@ -57,8 +57,8 @@ class UpdateLstController:
             notif.save()
 
     def _modify_tags(self, tag_ids):
-        if self._should_clear():
-            self._lst.custom_tags.clear()
+        if self._is_simple_update():
+            return
         for tag_id in tag_ids:
             if Tag.objects.filter(pk=tag_id):
                 tag = Tag.objects.get(pk=tag_id)
@@ -68,8 +68,8 @@ class UpdateLstController:
                     self._lst.custom_tags.add(tag)
 
     def _modify_shows(self, show_ids):
-        if self._should_clear():
-            self._lst.shows.clear()
+        if self._is_simple_update():
+            return
         modified_shows = []
         for show_id in show_ids:
             if Show.objects.filter(pk=show_id):
@@ -87,9 +87,9 @@ class UpdateLstController:
             self._create_edit_notification(shows_added=modified_shows)
 
     def _modify_collaborators(self, collaborator_ids):
+        if self._is_simple_update():
+            return
         old_collaborators = self._lst.collaborators.all()
-        if self._should_clear():
-            self._lst.collaborators.clear()
         for c_id in collaborator_ids:
             if User.objects.filter(pk=c_id):
                 collaborator = User.objects.get(pk=c_id)

--- a/src/flick/lst/tests/test_update_lst.py
+++ b/src/flick/lst/tests/test_update_lst.py
@@ -141,9 +141,10 @@ class UpdateLstTests(TestCase):
         self.assertEqual(data["id"], 5)
         self.assertEqual(data["name"], name)
         self.assertEqual(data["is_private"], is_private)
-        self.assertEqual(len(data["collaborators"]), 1)
-        self.assertEqual(len(data["shows"]), 2)
-        self.assertEqual(len(data["tags"]), 2)
+        # regular list update does not allow list-type fields to be modified!
+        self.assertEqual(len(data["collaborators"]), 0)
+        self.assertEqual(len(data["shows"]), 0)
+        self.assertEqual(len(data["tags"]), 0)
 
     def test_transfer_ownership_lst_edit_notification(self):
         self._create_list(collaborators=[2])

--- a/src/flick/notification/tests/test_list_invite_notification.py
+++ b/src/flick/notification/tests/test_list_invite_notification.py
@@ -14,7 +14,7 @@ class ListInviteNotificationTests(TestCase):
     LOGIN_URL = reverse("login")
     CREATE_LST_URL = reverse("lst-list")
     NOTIFICATIONS_URL = reverse("notif-list")
-    UPDATE_LST_URL = reverse("lst-detail", kwargs={"pk": 5})
+    ADD_TO_LST_URL = reverse("lst-detail-add", kwargs={"pk": 5})
     ME_URL = reverse("me")
 
     def setUp(self):
@@ -71,7 +71,7 @@ class ListInviteNotificationTests(TestCase):
         self.assertEqual(data["owner"]["id"], 1)
 
         request_data = {"name": "Alanna's Kdramas", "collaborators": [2], "shows": [], "tags": []}
-        response = self.client.post(self.UPDATE_LST_URL, request_data, format="json")
+        response = self.client.post(self.ADD_TO_LST_URL, request_data, format="json")
         self.assertEqual(response.status_code, 200)
         data = json.loads(response.content)["data"]
         self.assertEqual(data["id"], 5)


### PR DESCRIPTION
## Overview
Since we allow users to update a list's shows, tags, and collaborators via `/api/lsts/<id>/add/` and `/api/lsts/<id>/remove/`, we should get rid of this functionality for the simple `/api/lsts/<id>/` list update. This will simplify the use cases for supporting notifications.
## List update TLDR
**`POST /api/lsts/<id>/`**
* name
* is_private
* owner_id

**`POST /api/lsts/<id>/add/`**
* name, is_private, owner_id (all same expectations as the simple list update)
* shows
* tags
* collaborators

**`POST /api/lsts/<id>/remove/`**
* name, is_private, owner_id (all same expectations as the simple list update)
* shows
* tags
* collaborators



## Changes Made
* Remove functionality via a bool
* Fix tests



## Test Coverage
All tests pass except for @ViviYe 's failing profile test!



## Next Steps
Add support for adding and removing collaborators for the list edit notification #107 and #139 