### PR TITLE
Add check username

### DIFF
--- a/src/flick/api/urls.py
+++ b/src/flick/api/urls.py
@@ -7,6 +7,7 @@ from django.urls import include
 from django.urls import path
 from flick_auth import urls as auth_urls
 from flick_auth.views import AuthenticateView
+from flick_auth.views import CheckUsernameView
 from flick_auth.views import UserProfileView
 from flick_auth.views import UserView
 from friend.views import FriendAcceptListAndCreate
@@ -39,8 +40,6 @@ urlpatterns = [
     path("api-auth/", include("rest_framework.urls", namespace="rest_framework")),
     path("asset-bundles/", AssetBundleList.as_view(), name="asset-bundles-list"),
     path("asset-bundles/<int:pk>/", AssetBundleDetail.as_view(), name="asset-bundles-detail"),
-    path("me/", UserView.as_view(), name="me"),
-    path("user/<int:pk>", UserProfileView.as_view(), name="user-profile"),
     path("authenticate/", AuthenticateView.as_view(), name="authenticate"),
     path("auth/", include(auth_urls)),
     path("comment/<int:pk>/like/", LikeView.as_view(), name="like-comment"),
@@ -56,11 +55,14 @@ urlpatterns = [
     path("lsts/<int:pk>/", LstDetail.as_view(), name="lst-detail"),
     path("lsts/<int:pk>/add/", LstDetailAdd.as_view(), name="lst-detail-add"),
     path("lsts/<int:pk>/remove/", LstDetailRemove.as_view(), name="lst-detail-remove"),
+    path("me/", UserView.as_view(), name="me"),
     path("media/image/", UploadImage.as_view(), name="upload"),
     path("search/", Search.as_view(), name="search"),
-    path("tags/", TagList.as_view(), name="tag-list"),
-    path("tags/<int:pk>/", TagDetail.as_view(), name="tag-detail"),
     path("show/<int:pk>/", ShowDetail.as_view(), name="show-detail"),
     path("suggest/", PrivateSuggestionView.as_view(), name="private-suggestion"),
+    path("tags/", TagList.as_view(), name="tag-list"),
+    path("tags/<int:pk>/", TagDetail.as_view(), name="tag-detail"),
+    path("user/<int:pk>", UserProfileView.as_view(), name="user-profile"),
+    path("username/", CheckUsernameView.as_view(), name="check-username"),
     path("notifications/", NotificationList.as_view(), name="notif-list"),
 ]

--- a/src/flick/flick_auth/controllers/check_username_controller.py
+++ b/src/flick/flick_auth/controllers/check_username_controller.py
@@ -1,0 +1,17 @@
+from api.utils import failure_response
+from api.utils import success_response
+from django.contrib.auth.models import User
+
+
+class CheckUsernameController:
+    def __init__(self, request, data):
+        self._request = request
+        self._data = data
+
+    def process(self):
+        username = self._data.get("username")
+        if len(username) > 30:
+            return failure_response(f"{username} must be 30 characters or less.")
+        if User.objects.filter(username=username):
+            return failure_response(f"{username} is already taken.")
+        return success_response(f"{username} is available!")

--- a/src/flick/flick_auth/controllers/check_username_controller.py
+++ b/src/flick/flick_auth/controllers/check_username_controller.py
@@ -11,7 +11,9 @@ class CheckUsernameController:
     def process(self):
         username = self._data.get("username")
         if len(username) > 30:
-            return failure_response(f"{username} must be 30 characters or less.")
+            return failure_response("Username must be 30 characters or less.")
+        if len(username) < 3:
+            return failure_response("Username must be at least three characters.")
         if User.objects.filter(username=username):
-            return failure_response(f"{username} is already taken.")
-        return success_response(f"{username} is available!")
+            return failure_response("Username is already taken.")
+        return success_response("Username is available!")

--- a/src/flick/flick_auth/tests/test_check_username.py
+++ b/src/flick/flick_auth/tests/test_check_username.py
@@ -18,11 +18,19 @@ class CheckUsernameTests(TestCase):
         response = self.client.post(self.CHECK_USERNAME_URL, data)
         self.assertEqual(response.status_code, 404)
 
-    def test_username_30_char_limit(self):
+    def test_username_char_limit(self):
         data = {"username": "alannaalannaalannaalannaalanna"}
         response = self.client.post(self.CHECK_USERNAME_URL, data)
         self.assertEqual(response.status_code, 200)
 
         data = {"username": "alannaalannaalannaalannaalannaX"}
+        response = self.client.post(self.CHECK_USERNAME_URL, data)
+        self.assertEqual(response.status_code, 404)
+
+        data = {"username": "aaa"}
+        response = self.client.post(self.CHECK_USERNAME_URL, data)
+        self.assertEqual(response.status_code, 200)
+
+        data = {"username": "aa"}
         response = self.client.post(self.CHECK_USERNAME_URL, data)
         self.assertEqual(response.status_code, 404)

--- a/src/flick/flick_auth/tests/test_check_username.py
+++ b/src/flick/flick_auth/tests/test_check_username.py
@@ -1,0 +1,28 @@
+from django.contrib.auth.models import User
+from django.test import TestCase
+from django.urls import reverse
+
+
+class CheckUsernameTests(TestCase):
+    CHECK_USERNAME_URL = reverse("check-username")
+
+    def setUp(self):
+        User.objects.create(username="alanna", first_name="Alanna", last_name="Zhou")
+
+    def test_username_availability(self):
+        data = {"username": "alanna_zhou"}
+        response = self.client.post(self.CHECK_USERNAME_URL, data)
+        self.assertEqual(response.status_code, 200)
+
+        data = {"username": "alanna"}
+        response = self.client.post(self.CHECK_USERNAME_URL, data)
+        self.assertEqual(response.status_code, 404)
+
+    def test_username_30_char_limit(self):
+        data = {"username": "alannaalannaalannaalannaalanna"}
+        response = self.client.post(self.CHECK_USERNAME_URL, data)
+        self.assertEqual(response.status_code, 200)
+
+        data = {"username": "alannaalannaalannaalannaalannaX"}
+        response = self.client.post(self.CHECK_USERNAME_URL, data)
+        self.assertEqual(response.status_code, 404)

--- a/src/flick/flick_auth/views.py
+++ b/src/flick/flick_auth/views.py
@@ -15,6 +15,7 @@ from rest_framework import generics
 from rest_framework.authtoken.models import Token
 
 from .controllers.authenticate_controller import AuthenticateController
+from .controllers.check_username_controller import CheckUsernameController
 from .controllers.login_controller import LoginController
 from .controllers.register_controller import RegisterController
 from .controllers.update_profile_controller import UpdateProfileController
@@ -40,6 +41,15 @@ class UserView(generics.GenericAPIView):
         except json.JSONDecodeError:
             data = request.data
         return UpdateProfileController(request, data, self.serializer_class).process()
+
+
+class CheckUsernameView(generics.GenericAPIView):
+    def post(self, request):
+        try:
+            data = json.loads(request.body)
+        except json.JSONDecodeError:
+            data = request.data
+        return CheckUsernameController(request, data).process()
 
 
 class UserProfileView(generics.GenericAPIView):


### PR DESCRIPTION
## Overview
* Add an endpoint to help frontend see if a username is valid and available
* The reason why I'm doing a POST body request (and not a GET url param parse) is because in the future we might want to generate usernames based on user interest, so it'd be cool if users selected a couple of shows and then we generate a fun username for that :p
* Usernames must be in this range of character number: [3, 30] with bracket meaning inclusive 


## POST http://127.0.0.1:8000/api/username/
**Request Body:**
```
{
    "username": "alanna"
}
```
**Response Body:**
```
{
    "success": true,
    "data": "Username is available!"
}
```
_Note_: you can be sure that if `success` is true, then this username is both available and valid (is 30 char or less)

**Username unavailable response:**
```
{
    "success": false,
    "error": "Username is already taken."
}
```

**Username over 30 char response:**
```
{
    "success": false,
    "error": "Username must be 30 characters or less."
}
```
**Username under 3 char response:**
```
{
    "success": false,
    "error": "Username must be at least three characters."
}
```


## Changes Made
* Add new endpoint and controller (no need for serializer, response is trivial)
* Add new tests
* Make urls alphabetized


## Test Coverage
* All test pass except for the num mutual friends thing that Olivia and I were having issues with earlier lol

## Next Steps
* Get feedback from frontend on more stuff we can validate before registering a user

## Related PRs or Issues
Closes #165