### PR TITLE
Change discover to only have trending shows

### DIFF
--- a/src/flick/api/urls.py
+++ b/src/flick/api/urls.py
@@ -44,7 +44,7 @@ urlpatterns = [
     path("auth/", include(auth_urls)),
     path("comment/<int:pk>/like/", LikeView.as_view(), name="like-comment"),
     path("comment/<int:pk>/read/", ReadView.as_view(), name="read-comment"),
-    path("discover/show/", DiscoverShow.as_view(), name="discover-show"),
+    path("discover/", DiscoverShow.as_view(), name="discover-show"),
     path("friendship/", include("friendship.urls")),
     path("friends/", FriendList.as_view(), name="friend-list"),
     path("friends/request/", FriendRequestListAndCreate.as_view(), name="friend-request"),

--- a/src/flick/api/urls.py
+++ b/src/flick/api/urls.py
@@ -44,7 +44,7 @@ urlpatterns = [
     path("auth/", include(auth_urls)),
     path("comment/<int:pk>/like/", LikeView.as_view(), name="like-comment"),
     path("comment/<int:pk>/read/", ReadView.as_view(), name="read-comment"),
-    path("discover/", DiscoverShow.as_view(), name="discover-show"),
+    path("discover/", DiscoverShow.as_view(), name="discover"),
     path("friendship/", include("friendship.urls")),
     path("friends/", FriendList.as_view(), name="friend-list"),
     path("friends/request/", FriendRequestListAndCreate.as_view(), name="friend-request"),

--- a/src/flick/discover/tests/test_discover.py
+++ b/src/flick/discover/tests/test_discover.py
@@ -5,8 +5,8 @@ from django.urls import reverse
 from rest_framework.test import APIClient
 
 
-class SearchShowsTests(TransactionTestCase):
-    DISCOVER_URL = reverse("discover-show")
+class DiscoverTests(TransactionTestCase):
+    DISCOVER_URL = reverse("discover")
 
     def setUp(self):
         self.client = APIClient()

--- a/src/flick/discover/tests/test_discover.py
+++ b/src/flick/discover/tests/test_discover.py
@@ -1,0 +1,22 @@
+import json
+
+from django.test import TransactionTestCase
+from django.urls import reverse
+from rest_framework.test import APIClient
+
+
+class SearchShowsTests(TransactionTestCase):
+    DISCOVER_URL = reverse("discover-show")
+
+    def setUp(self):
+        self.client = APIClient()
+
+    def test_search_show(self):
+        response = self.client.get(self.DISCOVER_URL, format="json")
+        content = json.loads(response.content)
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(content.get("success"))
+        data = content.get("data")
+        self.assertEqual(len(data["trending_movies"]), 5)
+        self.assertEqual(len(data["trending_tvs"]), 5)
+        self.assertEqual(len(data["trending_animes"]), 5)

--- a/src/flick/discover/views.py
+++ b/src/flick/discover/views.py
@@ -2,6 +2,7 @@ from api.utils import success_response
 from django.core.cache import caches
 from rest_framework.views import APIView
 from show.show_api_utils import ShowAPI
+from show.simple_serializers import ShowSimplestSerializer
 from tag.models import Tag
 from tag.serializers import TagSerializer
 
@@ -10,38 +11,39 @@ local_cache = caches["local"]
 
 
 class DiscoverShow(APIView):
-    shows = []
-
     def get_shows_by_type(self, show_type, search_type, search_fn):
         shows = local_cache.get((search_type, show_type))
         if not shows:
             shows = search_fn(show_type)
             local_cache.set((search_type, show_type), shows)
-        self.shows.extend(shows)
+        return shows
 
     def get_top_shows(self, is_movie, is_tv, is_anime):
         if is_movie:
-            self.get_shows_by_type("movie", "top", ShowAPI.get_top_show_info)
+            movies = self.get_shows_by_type("movie", "top", ShowAPI.get_top_show_info)
         if is_tv:
-            self.get_shows_by_type("tv", "top", ShowAPI.get_top_show_info)
+            tvs = self.get_shows_by_type("tv", "top", ShowAPI.get_top_show_info)
         if is_anime:
-            self.get_shows_by_type("anime", "top", ShowAPI.get_top_show_info)
+            animes = self.get_shows_by_type("anime", "top", ShowAPI.get_top_show_info)
+        return movies, tvs, animes
 
     def get_popular_shows(self, is_movie, is_tv, is_anime):
         if is_movie:
-            self.get_shows_by_type("movie", "popular", ShowAPI.get_popular_show_info)
+            movies = self.get_shows_by_type("movie", "popular", ShowAPI.get_popular_show_info)[:5]
         if is_tv:
-            self.get_shows_by_type("tv", "popular", ShowAPI.get_popular_show_info)
+            tvs = self.get_shows_by_type("tv", "popular", ShowAPI.get_popular_show_info)[:5]
         if is_anime:
-            self.get_shows_by_type("anime", "popular", ShowAPI.get_popular_show_info)
+            animes = self.get_shows_by_type("anime", "popular", ShowAPI.get_popular_show_info)[:5]
+        return movies, tvs, animes
 
     def get_now_playing_shows(self, is_movie, is_tv, is_anime):
         if is_movie:
-            self.get_shows_by_type("movie", "now_playing", ShowAPI.get_now_playing_show_info)
+            movies = self.get_shows_by_type("movie", "now_playing", ShowAPI.get_now_playing_show_info)
         if is_tv:
-            self.get_shows_by_type("tv", "now_playing", ShowAPI.get_now_playing_show_info)
+            tvs = self.get_shows_by_type("tv", "now_playing", ShowAPI.get_now_playing_show_info)
         if is_anime:
-            self.get_shows_by_type("anime", "now_playing", ShowAPI.get_now_playing_show_info)
+            animes = self.get_shows_by_type("anime", "now_playing", ShowAPI.get_now_playing_show_info)
+        return movies, tvs, animes
 
     def get_top_shows_by_type_and_genre(self, show_type, tag_id):
         top_shows = local_cache.get(("top", show_type, tag_id))
@@ -50,46 +52,50 @@ class DiscoverShow(APIView):
             ext_api_genre_id = tag_data.get("ext_api_genre_id")
             top_shows = ShowAPI.get_top_show_info_by_genre(show_type, ext_api_genre_id)
             local_cache.set(("top", show_type, tag_id), top_shows)
-        self.shows.extend(top_shows)
+        return top_shows
 
     def get_top_shows_by_genre(self, is_movie, is_tv, is_anime, tag_id):
         if is_movie:
-            self.get_top_shows_by_type_and_genre("movie", tag_id)
+            movies = self.get_top_shows_by_type_and_genre("movie", tag_id)
         if is_tv:
-            self.get_top_shows_by_type_and_genre("tv", tag_id)
+            tvs = self.get_top_shows_by_type_and_genre("tv", tag_id)
         if is_anime:
-            self.get_shows_by_type(
+            animes = self.get_shows_by_type(
                 "anime", "top", ShowAPI.get_top_show_info
             )  # genre does not seem to be fully integrated in the anime api
+        return movies, tvs, animes
 
     def get(self, request, *args, **kwargs):
-        tag_id = request.query_params.get("tag_id", "")
-        print(f"genre: {tag_id}")
-        is_anime = bool(request.query_params.get("is_anime", False))
-        print(f"is_anime: {is_anime}")
-        is_movie = bool(request.query_params.get("is_movie", False))
-        print(f"is_movie: {is_movie}")
-        is_tv = bool(request.query_params.get("is_tv", False))
-        print(f"is_tv: {is_tv}")
-        is_top = bool(request.query_params.get("is_top", False))
-        print(f"is_top: {is_top}")
-        is_now = bool(request.query_params.get("is_now", False))
-        print(f"is_now: {is_now}")
-        is_popular = bool(request.query_params.get("is_popular", False))
-        print(f"is_popular: {is_popular}")
+        # tag_id = request.query_params.get("tag_id", "")
+        # print(f"genre: {tag_id}")
+        # is_anime = bool(request.query_params.get("is_anime", False))
+        # print(f"is_anime: {is_anime}")
+        # is_movie = bool(request.query_params.get("is_movie", False))
+        # print(f"is_movie: {is_movie}")
+        # is_tv = bool(request.query_params.get("is_tv", False))
+        # print(f"is_tv: {is_tv}")
+        # is_top = bool(request.query_params.get("is_top", False))
+        # print(f"is_top: {is_top}")
+        # is_now = bool(request.query_params.get("is_now", False))
+        # print(f"is_now: {is_now}")
+        # is_popular = bool(request.query_params.get("is_popular", False))
+        # print(f"is_popular: {is_popular}")
 
-        self.shows = []
+        # self.shows = []
 
-        if tag_id:
-            self.get_top_shows_by_genre(is_movie, is_tv, is_anime, tag_id)
-        elif is_now:
-            self.get_now_playing_shows(is_movie, is_tv, is_anime)
-        elif is_popular:
-            self.get_popular_shows(is_movie, is_tv, is_anime)
-        elif is_top:
-            self.get_top_shows(is_movie, is_tv, is_anime)
+        # if tag_id:
+        #     self.get_top_shows_by_genre(is_movie, is_tv, is_anime, tag_id)
+        # elif is_now:
+        #     self.get_now_playing_shows(is_movie, is_tv, is_anime)
+        # elif is_popular:
+        #     self.get_popular_shows(is_movie, is_tv, is_anime)
+        # elif is_top:
+        #     self.get_top_shows(is_movie, is_tv, is_anime)
 
-        serializer_data = []
-        serializer_data.extend(ShowAPI.create_show_objects(self.shows))
+        movies, tvs, animes = self.get_popular_shows(True, True, True)
+        serializer_data = dict()
+        serializer_data["trending_movies"] = ShowAPI.create_show_objects(movies, ShowSimplestSerializer)
+        serializer_data["trending_tvs"] = ShowAPI.create_show_objects(tvs, ShowSimplestSerializer)
+        serializer_data["trending_animes"] = ShowAPI.create_show_objects(animes, ShowSimplestSerializer)
 
         return success_response(serializer_data)

--- a/src/flick/show/show_api_utils.py
+++ b/src/flick/show/show_api_utils.py
@@ -9,7 +9,7 @@ from .tmdb_api_utils import TMDB_API
 
 class ShowAPI:
     @staticmethod
-    def create_show_objects(show_info_lst, custom_serializer=ShowSearchSerializer):
+    def create_show_objects(show_info_lst, serializer=ShowSearchSerializer):
         serializer_data = []
         for show_info in show_info_lst:
             if not show_info:
@@ -24,8 +24,8 @@ class ShowAPI:
                     ext_api_id=show_info.get("ext_api_id"),
                     ext_api_source=show_info.get("ext_api_source"),
                 )
-                serializer = custom_serializer(show)
-                serializer_data.append(serializer.data)
+                s = serializer(show)
+                serializer_data.append(s.data)
             else:
                 try:
                     show = Show()
@@ -42,8 +42,8 @@ class ShowAPI:
                     show.seasons = show_info.get("seasons")
                     show.save()
                     populate_show_details.delay(show.id)
-                    serializer = custom_serializer(show)
-                    serializer_data.append(serializer.data)
+                    s = serializer(show)
+                    serializer_data.append(s.data)
                 except Exception as e:
                     print("create_show_objects:", e)
         return serializer_data

--- a/src/flick/show/show_api_utils.py
+++ b/src/flick/show/show_api_utils.py
@@ -9,7 +9,7 @@ from .tmdb_api_utils import TMDB_API
 
 class ShowAPI:
     @staticmethod
-    def create_show_objects(show_info_lst):
+    def create_show_objects(show_info_lst, custom_serializer=ShowSearchSerializer):
         serializer_data = []
         for show_info in show_info_lst:
             if not show_info:
@@ -24,7 +24,7 @@ class ShowAPI:
                     ext_api_id=show_info.get("ext_api_id"),
                     ext_api_source=show_info.get("ext_api_source"),
                 )
-                serializer = ShowSearchSerializer(show)
+                serializer = custom_serializer(show)
                 serializer_data.append(serializer.data)
             else:
                 try:
@@ -42,7 +42,7 @@ class ShowAPI:
                     show.seasons = show_info.get("seasons")
                     show.save()
                     populate_show_details.delay(show.id)
-                    serializer = ShowSearchSerializer(show)
+                    serializer = custom_serializer(show)
                     serializer_data.append(serializer.data)
                 except Exception as e:
                     print("create_show_objects:", e)


### PR DESCRIPTION
## Overview
Change discover to be one endpoint holding trending shows

## Test Coverage
Tests pass other than the mutual friends thing

## Next Steps
add friend activity???

## Related PRs or Issues
closes #168 

## Sample Response
`GET`  http://127.0.0.1:8000/api/discover/
[Discover.txt](https://github.com/flickchicks/flick-backend/files/5213348/Discover.txt)
Discover now has 5 "trending_movies", 5 "trending_tvs" and 5 "trending_animes"
- Log in **not** required