### PR TITLE
Return query with search response

### DIFF
--- a/src/flick/api/utils.py
+++ b/src/flick/api/utils.py
@@ -8,3 +8,11 @@ def success_response(data, status=status.HTTP_200_OK):
 
 def failure_response(message, status=status.HTTP_404_NOT_FOUND):
     return Response({"success": False, "error": message}, status=status)
+
+
+def success_response_with_query(query, data, status=status.HTTP_200_OK):
+    return Response({"success": True, "query": query, "data": data}, status=status)
+
+
+def failure_response_with_query(query, message, status=status.HTTP_404_NOT_FOUND):
+    return Response({"success": False, "query": query, "error": message}, status=status)

--- a/src/flick/search/tests/test_search_shows.py
+++ b/src/flick/search/tests/test_search_shows.py
@@ -40,11 +40,13 @@ class SearchShowsTests(TransactionTestCase):
 
     def test_search_show(self):
         self.client.credentials(HTTP_AUTHORIZATION="Token " + self.user_token)
-        data = {"is_movie": True, "query": "Maleficent"}
+        query = "Maleficent"
+        data = {"is_movie": True, "query": query}
         response = self.client.get(self.SEARCH_URL, data, format="json")
         content = json.loads(response.content)
         self.assertEqual(response.status_code, 200)
         self.assertTrue(content.get("success"))
+        self.assertEqual(content.get("query"), query)
         data = content.get("data")[0]
         self.assertIn("id", data)
         self.assertIn("title", data)

--- a/src/flick/search/tests/test_search_tags.py
+++ b/src/flick/search/tests/test_search_tags.py
@@ -44,11 +44,13 @@ class SearchTagsTests(TestCase):
         Tag.objects.create(name="amazing")
         Tag.objects.create(name="hhhhh")
         Tag.objects.create(name="Another")
-        data = {"is_tag": True, "query": "a"}
+        query = "a"
+        data = {"is_tag": True, "query": query}
         response = self.client.get(self.SEARCH_URL, data, format="json")
         content = json.loads(response.content)
         self.assertEqual(response.status_code, 200)
         self.assertTrue(content.get("success"))
+        self.assertEqual(content.get("query"), query)
         data = content.get("data")
         self.assertEqual(len(data), 2)
         self.assertEqual(data[0]["name"], "amazing")

--- a/src/flick/search/tests/test_search_users.py
+++ b/src/flick/search/tests/test_search_users.py
@@ -65,6 +65,7 @@ class SearchUsersTests(TestCase):
         content = json.loads(response.content)
         self.assertEqual(response.status_code, 200)
         self.assertTrue(content.get("success"))
+        self.assertEqual(content.get("query"), self.friend3.username)
         data = content.get("data")[0]
         self.assertEqual(data["id"], self.friend3.id)
         self.assertEqual(data["username"], self.friend3.username)

--- a/src/flick/search/views.py
+++ b/src/flick/search/views.py
@@ -1,7 +1,7 @@
 from user.user_simple_serializers import UserSimpleSerializer
 
 from api import settings as api_settings
-from api.utils import success_response
+from api.utils import success_response_with_query
 from django.contrib.auth.models import User
 from django.core.cache import caches
 from django.db.models import Q
@@ -89,11 +89,11 @@ class Search(APIView):
         self.known_shows = []
 
         if is_user:
-            return success_response(self.get_users_by_username(query))
+            return success_response_with_query(query=query, data=self.get_users_by_username(query))
         elif is_lst:
-            return success_response(self.get_lsts_by_name(query))
+            return success_response_with_query(query=query, data=self.get_lsts_by_name(query))
         elif is_tag:
-            return success_response(self.get_tags_by_name(query))
+            return success_response_with_query(query=query, data=self.get_tags_by_name(query))
         else:
             self.get_shows_by_query(query, is_movie, is_tv, is_anime, tags)
 
@@ -101,4 +101,4 @@ class Search(APIView):
         serializer_data.extend(ShowAPI.create_show_objects(self.shows))
         serializer_data.extend(self.known_shows)
 
-        return success_response(serializer_data)
+        return success_response_with_query(query=query, data=serializer_data)


### PR DESCRIPTION
## Overview
Add new JSON key "query" with the field being the search query, this applies to:
* search shows
* search users
* search tags


## Test Coverage
Search tests pass
```
(venv) ~/D/f/s/flick ❯❯❯ python manage.py test search.tests
Creating test database for alias 'default'...
System check identified no issues (0 silenced).
...
----------------------------------------------------------------------
Ran 3 tests in 1.540s

OK
Destroying test database for alias 'default'...

3 slowest tests:
0.7229s test_search_user (search.tests.test_search_users.SearchUsersTests)
0.6177s test_search_show (search.tests.test_search_shows.SearchShowsTests)
0.1987s test_search_tag (search.tests.test_search_tags.SearchTagsTests)
```
## Related PRs or Issues
Closes #174 
