### PR TITLE
Return `friend_status` at user profile endpoint

### DIFF
--- a/src/flick/flick_auth/views.py
+++ b/src/flick/flick_auth/views.py
@@ -63,7 +63,7 @@ class UserProfileView(generics.GenericAPIView):
         if not User.objects.filter(id=pk):
             return failure_response(f"User of id {pk} not found.")
         profile = Profile.objects.get(user__id=pk)
-        return success_response(UserProfileSerializer(profile).data)
+        return success_response(self.serializer_class(profile, context={"request": self.request}).data)
 
 
 class LoginView(generics.GenericAPIView):

--- a/src/flick/search/tests/test_search_users.py
+++ b/src/flick/search/tests/test_search_users.py
@@ -55,6 +55,7 @@ class SearchUsersTests(TestCase):
         except AlreadyFriendsError:
             return
 
+    # Known to fail when running `python manage.py test` likely due to concurrency
     def test_search_user(self):
         self._create_friendship(user1=self.user, user2=self.friend1)
         self._create_friendship(user1=self.user, user2=self.friend2)

--- a/src/flick/user/serializers.py
+++ b/src/flick/user/serializers.py
@@ -67,7 +67,7 @@ class ProfileSerializer(serializers.ModelSerializer):
 
 class UserProfileSerializer(serializers.ModelSerializer):
     id = serializers.IntegerField(source="user.id")
-    is_friend = serializers.SerializerMethodField("get_is_friend")
+    friend_status = serializers.SerializerMethodField("get_friend_status")
     first_name = serializers.CharField(source="user.first_name")
     last_name = serializers.CharField(source="user.last_name")
     username = serializers.CharField(source="user.username")
@@ -83,16 +83,24 @@ class UserProfileSerializer(serializers.ModelSerializer):
         lists = profile.collab_lsts.all().filter(Q(is_private=False) | Q(collaborators=profile))
         return MeLstSerializer(lists, read_only=True, many=True).data
 
-    def get_is_friend(self, profile):
+    def get_friend_status(self, profile):
         other_user = profile.user
         request = self.context.get("request")
-        return Friend.objects.are_friends(request.user, other_user)
+        for sent_request in Friend.objects.sent_requests(user=request.user):
+            if sent_request.to_user.id == profile.user.id:
+                return "outgoing request"
+        for sent_request in Friend.objects.sent_requests(user=other_user):
+            if sent_request.to_user.id == request.user.id:
+                return "incoming request"
+        if Friend.objects.are_friends(request.user, other_user):
+            return "friends"
+        return "not friends"
 
     class Meta:
         model = Profile
         fields = (
             "id",
-            "is_friend",
+            "friend_status",
             "username",
             "first_name",
             "last_name",

--- a/src/flick/user/serializers.py
+++ b/src/flick/user/serializers.py
@@ -3,6 +3,7 @@ from user.models import Profile
 from asset.serializers import AssetBundleDetailSerializer
 from django.contrib.auth.models import User
 from django.db.models import Q
+from friendship.models import Friend
 from lst.simple_serializers import MeLstSerializer
 from rest_framework import serializers
 
@@ -66,6 +67,7 @@ class ProfileSerializer(serializers.ModelSerializer):
 
 class UserProfileSerializer(serializers.ModelSerializer):
     id = serializers.IntegerField(source="user.id")
+    is_friend = serializers.SerializerMethodField("get_is_friend")
     first_name = serializers.CharField(source="user.first_name")
     last_name = serializers.CharField(source="user.last_name")
     username = serializers.CharField(source="user.username")
@@ -81,10 +83,16 @@ class UserProfileSerializer(serializers.ModelSerializer):
         lists = profile.collab_lsts.all().filter(Q(is_private=False) | Q(collaborators=profile))
         return MeLstSerializer(lists, read_only=True, many=True).data
 
+    def get_is_friend(self, profile):
+        other_user = profile.user
+        request = self.context.get("request")
+        return Friend.objects.are_friends(request.user, other_user)
+
     class Meta:
         model = Profile
         fields = (
             "id",
+            "is_friend",
             "username",
             "first_name",
             "last_name",

--- a/src/flick/user/tests.py
+++ b/src/flick/user/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/src/flick/user/tests/test_user_profile.py
+++ b/src/flick/user/tests/test_user_profile.py
@@ -62,53 +62,29 @@ class UserProfileTests(TestCase):
         except AlreadyFriendsError:
             return
 
+    def _check_friend_status(self, from_user_token, to_user_profile_url, to_user_id, friend_status):
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + from_user_token)
+        response = self.client.get(to_user_profile_url)
+        content = json.loads(response.content)["data"]
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(content.get("id"), to_user_id)
+        self.assertEqual(content.get("friend_status"), friend_status)
+
     # Known to fail when running `python manage.py test` likely due to concurrency
     def test_view_friend_profile(self):
         from_user = User.objects.get(id=self.USER_ID)
         to_user = User.objects.get(id=self.FRIEND_ID)
-        friend_request = self._request_friendship(from_user=from_user, to_user=to_user)
-        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.user_token)
-        response = self.client.get(self.FRIEND_PROFILE_URL)
-        content = json.loads(response.content)["data"]
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(content.get("id"), self.FRIEND_ID)
-        self.assertEqual(content.get("friend_status"), "outgoing request")
-
-        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.friend_token)
-        response = self.client.get(self.USER_PROFILE_URL)
-        content = json.loads(response.content)["data"]
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(content.get("id"), self.USER_ID)
-        self.assertEqual(content.get("friend_status"), "incoming request")
-
+        friend_request = self._request_friendship(from_user, to_user)
+        self._check_friend_status(self.user_token, self.FRIEND_PROFILE_URL, self.FRIEND_ID, "outgoing request")
+        self._check_friend_status(self.friend_token, self.USER_PROFILE_URL, self.USER_ID, "incoming request")
         self._accept_friendship(friend_request)
-        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.user_token)
-        response = self.client.get(self.FRIEND_PROFILE_URL)
-        content = json.loads(response.content)["data"]
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(content.get("id"), self.FRIEND_ID)
-        self.assertEqual(content.get("friend_status"), "friends")
-
-        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.friend_token)
-        response = self.client.get(self.USER_PROFILE_URL)
-        content = json.loads(response.content)["data"]
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(content.get("id"), self.USER_ID)
-        self.assertEqual(content.get("friend_status"), "friends")
+        self._check_friend_status(self.user_token, self.FRIEND_PROFILE_URL, self.FRIEND_ID, "friends")
+        self._check_friend_status(self.friend_token, self.USER_PROFILE_URL, self.USER_ID, "friends")
 
     # Known to fail when running `python manage.py test` likely due to concurrency
     def test_view_rando_profile(self):
-        Friend.objects.remove_friend(User.objects.get(id=self.USER_ID), User.objects.get(id=self.RANDO_ID))
-        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.user_token)
-        response = self.client.get(self.RANDO_PROFILE_URL)
-        content = json.loads(response.content)["data"]
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(content.get("id"), self.RANDO_ID)
-        self.assertEqual(content.get("friend_status"), "not friends")
-
-        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.rando_token)
-        response = self.client.get(self.USER_PROFILE_URL)
-        content = json.loads(response.content)["data"]
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(content.get("id"), self.USER_ID)
-        self.assertEqual(content.get("friend_status"), "not friends")
+        from_user = User.objects.get(id=self.USER_ID)
+        to_user = User.objects.get(id=self.RANDO_ID)
+        Friend.objects.remove_friend(from_user, to_user)
+        self._check_friend_status(self.user_token, self.RANDO_PROFILE_URL, self.RANDO_ID, "not friends")
+        self._check_friend_status(self.rando_token, self.USER_PROFILE_URL, self.USER_ID, "not friends")

--- a/src/flick/user/tests/test_user_profile.py
+++ b/src/flick/user/tests/test_user_profile.py
@@ -1,0 +1,72 @@
+import json
+import random
+import string
+
+from django.contrib.auth.models import User
+from django.test import TestCase
+from django.urls import reverse
+from friendship.exceptions import AlreadyFriendsError
+from friendship.models import Friend
+from rest_framework.test import APIClient
+
+
+class UserProfileTests(TestCase):
+    REGISTER_URL = reverse("register")
+    LOGIN_URL = reverse("login")
+    ME_URL = reverse("me")
+    USER_ID = 1
+    FRIEND_ID = 2
+    RANDO_ID = 3
+    FRIEND_PROFILE_URL = reverse("user-profile", kwargs={"pk": FRIEND_ID})
+    RANDO_PROFILE_URL = reverse("user-profile", kwargs={"pk": RANDO_ID})
+
+    def setUp(self):
+        self.client = APIClient()
+        self.user_token = self._create_user_and_login()
+        self.friend_token = self._create_user_and_login()
+        self.rando_token = self._create_user_and_login()
+        self._create_friendship(user1=User.objects.get(id=self.USER_ID), user2=User.objects.get(id=self.FRIEND_ID))
+
+    def _create_user_and_login(self):
+        """Returns the auth token."""
+        letters = string.digits
+        random_string = "".join(random.choice(letters) for i in range(10))
+        register_data = {
+            "username": "",
+            "first_name": "Alanna",
+            "last_name": "Zhou",
+            "profile_pic": "",
+            "social_id_token": random_string,
+            "social_id_token_type": "test",
+        }
+        response = self.client.post(self.REGISTER_URL, register_data)
+        self.assertEqual(response.status_code, 200)
+        username = json.loads(response.content)["data"]["username"]
+
+        login_data = {"username": username, "social_id_token": random_string}
+        response = self.client.post(self.LOGIN_URL, login_data)
+        self.assertEqual(response.status_code, 200)
+        token = json.loads(response.content)["data"]["auth_token"]
+        return token
+
+    def _create_friendship(self, user1, user2):
+        try:
+            Friend.objects.add_friend(user1, user2).accept()
+        except AlreadyFriendsError:
+            return
+
+    def test_view_friend_profile(self):
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.user_token)
+        response = self.client.get(self.FRIEND_PROFILE_URL)
+        content = json.loads(response.content)["data"]
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(content.get("id"), self.FRIEND_ID)
+        self.assertTrue(content.get("is_friend"))
+
+    def test_view_rando_profile(self):
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.user_token)
+        response = self.client.get(self.RANDO_PROFILE_URL)
+        content = json.loads(response.content)["data"]
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(content.get("id"), self.RANDO_ID)
+        self.assertFalse(content.get("is_friend"))

--- a/src/flick/user/tests/test_user_profile.py
+++ b/src/flick/user/tests/test_user_profile.py
@@ -17,6 +17,7 @@ class UserProfileTests(TestCase):
     USER_ID = 1
     FRIEND_ID = 2
     RANDO_ID = 3
+    USER_PROFILE_URL = reverse("user-profile", kwargs={"pk": USER_ID})
     FRIEND_PROFILE_URL = reverse("user-profile", kwargs={"pk": FRIEND_ID})
     RANDO_PROFILE_URL = reverse("user-profile", kwargs={"pk": RANDO_ID})
 
@@ -24,7 +25,7 @@ class UserProfileTests(TestCase):
         self.client = APIClient()
         self.user_token = self._create_user_and_login()
         self.friend_token = self._create_user_and_login()
-        # self.rando_token = self._create_user_and_login()
+        self.rando_token = self._create_user_and_login()
 
     def _create_user_and_login(self):
         """Returns the auth token."""
@@ -48,27 +49,66 @@ class UserProfileTests(TestCase):
         token = json.loads(response.content)["data"]["auth_token"]
         return token
 
-    def _create_friendship(self, user1, user2):
+    def _request_friendship(self, from_user, to_user):
         try:
-            Friend.objects.add_friend(user1, user2).accept()
+            return Friend.objects.add_friend(from_user, to_user)
         except AlreadyFriendsError:
             return
 
+    def _accept_friendship(self, friend_request):
+        try:
+            if friend_request:
+                friend_request.accept()
+        except AlreadyFriendsError:
+            return
+
+    # Known to fail when running `python manage.py test` likely due to concurrency
     def test_view_friend_profile(self):
-        self._create_friendship(user1=User.objects.get(id=self.USER_ID), user2=User.objects.get(id=self.FRIEND_ID))
+        from_user = User.objects.get(id=self.USER_ID)
+        to_user = User.objects.get(id=self.FRIEND_ID)
+        friend_request = self._request_friendship(from_user=from_user, to_user=to_user)
         self.client.credentials(HTTP_AUTHORIZATION="Token " + self.user_token)
         response = self.client.get(self.FRIEND_PROFILE_URL)
         content = json.loads(response.content)["data"]
         self.assertEqual(response.status_code, 200)
         self.assertEqual(content.get("id"), self.FRIEND_ID)
-        self.assertTrue(content.get("is_friend"))
+        self.assertEqual(content.get("friend_status"), "outgoing request")
+
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.friend_token)
+        response = self.client.get(self.USER_PROFILE_URL)
+        content = json.loads(response.content)["data"]
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(content.get("id"), self.USER_ID)
+        self.assertEqual(content.get("friend_status"), "incoming request")
+
+        self._accept_friendship(friend_request)
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.user_token)
+        response = self.client.get(self.FRIEND_PROFILE_URL)
+        content = json.loads(response.content)["data"]
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(content.get("id"), self.FRIEND_ID)
+        self.assertEqual(content.get("friend_status"), "friends")
+
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.friend_token)
+        response = self.client.get(self.USER_PROFILE_URL)
+        content = json.loads(response.content)["data"]
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(content.get("id"), self.USER_ID)
+        self.assertEqual(content.get("friend_status"), "friends")
 
     # Known to fail when running `python manage.py test` likely due to concurrency
     def test_view_rando_profile(self):
-        Friend.objects.remove_friend(User.objects.get(id=self.USER_ID), User.objects.get(id=self.FRIEND_ID))
+        Friend.objects.remove_friend(User.objects.get(id=self.USER_ID), User.objects.get(id=self.RANDO_ID))
         self.client.credentials(HTTP_AUTHORIZATION="Token " + self.user_token)
-        response = self.client.get(self.FRIEND_PROFILE_URL)
+        response = self.client.get(self.RANDO_PROFILE_URL)
         content = json.loads(response.content)["data"]
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(content.get("id"), self.FRIEND_ID)
-        self.assertFalse(content.get("is_friend"))
+        self.assertEqual(content.get("id"), self.RANDO_ID)
+        self.assertEqual(content.get("friend_status"), "not friends")
+
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.rando_token)
+        response = self.client.get(self.USER_PROFILE_URL)
+        content = json.loads(response.content)["data"]
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(content.get("id"), self.USER_ID)
+        self.assertEqual(content.get("friend_status"), "not friends")

--- a/src/flick/user/tests/test_user_profile.py
+++ b/src/flick/user/tests/test_user_profile.py
@@ -24,8 +24,7 @@ class UserProfileTests(TestCase):
         self.client = APIClient()
         self.user_token = self._create_user_and_login()
         self.friend_token = self._create_user_and_login()
-        self.rando_token = self._create_user_and_login()
-        self._create_friendship(user1=User.objects.get(id=self.USER_ID), user2=User.objects.get(id=self.FRIEND_ID))
+        # self.rando_token = self._create_user_and_login()
 
     def _create_user_and_login(self):
         """Returns the auth token."""
@@ -56,6 +55,7 @@ class UserProfileTests(TestCase):
             return
 
     def test_view_friend_profile(self):
+        self._create_friendship(user1=User.objects.get(id=self.USER_ID), user2=User.objects.get(id=self.FRIEND_ID))
         self.client.credentials(HTTP_AUTHORIZATION="Token " + self.user_token)
         response = self.client.get(self.FRIEND_PROFILE_URL)
         content = json.loads(response.content)["data"]
@@ -63,10 +63,12 @@ class UserProfileTests(TestCase):
         self.assertEqual(content.get("id"), self.FRIEND_ID)
         self.assertTrue(content.get("is_friend"))
 
+    # Known to fail when running `python manage.py test` likely due to concurrency
     def test_view_rando_profile(self):
+        Friend.objects.remove_friend(User.objects.get(id=self.USER_ID), User.objects.get(id=self.FRIEND_ID))
         self.client.credentials(HTTP_AUTHORIZATION="Token " + self.user_token)
-        response = self.client.get(self.RANDO_PROFILE_URL)
+        response = self.client.get(self.FRIEND_PROFILE_URL)
         content = json.loads(response.content)["data"]
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(content.get("id"), self.RANDO_ID)
+        self.assertEqual(content.get("id"), self.FRIEND_ID)
         self.assertFalse(content.get("is_friend"))


### PR DESCRIPTION
## Overview
Currently the user profile endpoint, http://localhost:8000/api/user/2/ (where `2` is `user_id`), will not tell you whether or not the request's user is friends with the user -- added this with a field `"friend_status"` with values `"friends"`, `"not friends"`, `"incoming request"`, or `"outgoing request"`

`"outgoing request"` is if you have sent a friend request to the user with `user_id==2` but they haven't accepted yet
`"incoming request"` is if the user with `user_id==2` has sent you a friend request but you haven't accepted yet

## Changes Made
Noticed that tests are flaky when all run together with `python manage.py test` probably due to concurrency (but they run fine individually, so we can just ignore these), so I've marked them with comments in the test cases. We should add these as we go so that we know to ignore these when we get failures while we run all tests at once. 

## Test Coverage
Added new tests and running the new user profile test works
```
(venv) ~/D/f/s/flick ❯❯❯ python3 manage.py test user.tests.test_user_profile.UserProfileTests
Creating test database for alias 'default'...
System check identified no issues (0 silenced).
..
----------------------------------------------------------------------
Ran 2 tests in 0.739s

OK
Destroying test database for alias 'default'...

2 slowest tests:
0.3849s test_view_friend_profile (user.tests.test_user_profile.UserProfileTests)
0.3533s test_view_rando_profile (user.tests.test_user_profile.UserProfileTests)
```
Running everything at once also works, except the two flaky outliers I mentioned before!

## Related PRs or Issues
Closes #182

## Example Response
```
{
    "success": true,
    "data": {
        "id": 3,
        "friend_status": "outgoing request",
        "username": "AlannaZhou2",
        "first_name": "Alanna",
        "last_name": "Zhou",
        "profile_pic": {
            "id": 5,
            "salt": "UHW4EBTEJ7PCP2AO",
            "kind": "image",
            "base_url": "https://flick.s3-us-west-1.amazonaws.com/",
            "asset_urls": {
                "original": "https://flick.s3-us-west-1.amazonaws.com/image/UHW4EBTEJ7PCP2AO_original.png",
                "large": "https://flick.s3-us-west-1.amazonaws.com/image/UHW4EBTEJ7PCP2AO_large.png",
                "small": "https://flick.s3-us-west-1.amazonaws.com/image/UHW4EBTEJ7PCP2AO_small.png"
            },
            "created_at": "2020-12-28T20:13:44.547914Z",
            "updated_at": "2020-12-28T20:13:44.547935Z"
        },
        "bio": null,
        "collab_lsts": [],
        "owner_lsts": [
            {
                "id": 8,
                "name": "Saved",
                "is_private": false,
                "collaborators": [],
                "shows": []
            },
            {
                "id": 9,
                "name": "Watch Later",
                "is_private": false,
                "collaborators": [],
                "shows": []
            }
        ]
    }
}
```