### PR TITLE
Fix lst_lst.name error when not sending in a `name` in update and add/remove to list

### DIFF
--- a/src/flick/lst/controllers/update_lst_controller.py
+++ b/src/flick/lst/controllers/update_lst_controller.py
@@ -161,7 +161,8 @@ class UpdateLstController:
             self._modify_shows(show_ids)
             self._modify_tags(tag_ids)
             if not (self._lst.is_saved or self._lst.is_watch_later):
-                self._lst.name = name
+                if name:
+                    self._lst.name = name
                 self._lst.lst_pic = lst_pic
                 self._modify_collaborators(collaborator_ids)
                 if self._user.id != owner_id and Profile.objects.filter(user__id=owner_id):

--- a/src/flick/lst/tests/test_update_lst.py
+++ b/src/flick/lst/tests/test_update_lst.py
@@ -20,6 +20,7 @@ class UpdateLstTests(TestCase):
     UPDATE_LST_URL = reverse("lst-detail", kwargs={"pk": LST_ID})
     ADD_TO_LST_URL = reverse("lst-detail-add", kwargs={"pk": LST_ID})
     REMOVE_FROM_LST_URL = reverse("lst-detail-remove", kwargs={"pk": LST_ID})
+    OLD_LST_NAME = "Alanna's Kdramas"
 
     def setUp(self):
         self.client = APIClient()
@@ -84,7 +85,7 @@ class UpdateLstTests(TestCase):
     def _create_list(self, collaborators=[], shows=[]):
         self.client.credentials(HTTP_AUTHORIZATION="Token " + self.user_token)
         request_data = {
-            "name": "Alanna's Kdramas",
+            "name": self.OLD_LST_NAME,
             "is_private": False,
             "collaborators": collaborators,
             "shows": shows,
@@ -154,6 +155,20 @@ class UpdateLstTests(TestCase):
         data = self._update_list(name=name, is_private=is_private, collaborators=[2], shows=show_ids, tags=tag_ids)
         self.assertEqual(data["id"], self.LST_ID)
         self.assertEqual(data["name"], name)
+        self.assertEqual(data["is_private"], is_private)
+        # regular list update does not allow list-type fields to be modified!
+        self.assertEqual(len(data["collaborators"]), 0)
+        self.assertEqual(len(data["shows"]), 0)
+        self.assertEqual(len(data["tags"]), 0)
+
+    def test_update_lst_no_name(self):
+        self._create_list()
+        show_ids = self._get_created_show_ids(num_shows=2)
+        tag_ids = self._get_created_tag_ids(num_tags=2)
+        is_private = True
+        data = self._update_list(is_private=is_private, collaborators=[2], shows=show_ids, tags=tag_ids)
+        self.assertEqual(data["id"], self.LST_ID)
+        self.assertEqual(data["name"], self.OLD_LST_NAME)
         self.assertEqual(data["is_private"], is_private)
         # regular list update does not allow list-type fields to be modified!
         self.assertEqual(len(data["collaborators"]), 0)


### PR DESCRIPTION
## Overview
Before, if you didn't send in `name` to the update list and add/remote to list endpoints, you'd get a null constraint error on the `name` field. Turns out it was a very trivial bug! 
I know I told @haiyingweng that you have to send in `name` at the update list endpoint, but this is no longer true (feel free to just omit `name` if you want to keep the current lst name!)

## Changes Made
Just check if we actually received a name or not--if we didn't then we just keep the old name. Added a new test too.

## Test Coverage
All update list tests pass, in addition to the new test!
```
(venv) ~/D/f/s/flick ❯❯❯ python manage.py test lst.tests.test_update_lst.UpdateLstTests
Creating test database for alias 'default'...
System check identified no issues (0 silenced).
........
----------------------------------------------------------------------
Ran 8 tests in 4.560s

OK
Destroying test database for alias 'default'...

8 slowest tests:
0.6044s test_collaborators_modified_by_owner_lst_edit_notification (lst.tests.test_update_lst.UpdateLstTests)
0.5930s test_collaborators_modified_by_collaborator_lst_edit_notification (lst.tests.test_update_lst.UpdateLstTests)
0.5829s test_add_and_remove_from_lst (lst.tests.test_update_lst.UpdateLstTests)
0.5781s test_shows_added_to_lst_edit_notification (lst.tests.test_update_lst.UpdateLstTests)
0.5753s test_shows_removed_from_lst_edit_notification (lst.tests.test_update_lst.UpdateLstTests)
0.5491s test_transfer_ownership_lst_edit_notification (lst.tests.test_update_lst.UpdateLstTests)
0.5437s test_update_lst (lst.tests.test_update_lst.UpdateLstTests)
0.5319s test_update_lst_no_name (lst.tests.test_update_lst.UpdateLstTests)
```

## Related PRs or Issues
Closes #192 

## Examples
### Works with update list of id `15`
**http://127.0.0.1:8000/api/lsts/15/**
Valid Request Bodies:
```
{
  "name": "alanna's movies",
  "is_private": false,
  "owner": 2
}
```
or
```
{
  "is_private": false,
  "owner": 2
}
```
Note: Remember that you can no longer edit `collaborators`, `tags`, nor `shows` at just the update list endpoint (if you want to do so, use `/add/` and `/remove/` -- check the Dropbox Paper doc for more details!)

### Works with add/remove from list of id `15`
**http://127.0.0.1:8000/api/lsts/15/add/** or **http://127.0.0.1:8000/api/lsts/15/remove/**
Valid Request Bodies:
```
{
    "name": "Alanna's kdramazzz",
    "shows": [10, 11],
    "tags": [2],
    "collaborators": [1]
}
```
or
```
{
    "shows": [10, 11],
    "tags": [2],
    "collaborators": [1]
}
```
