### PR TITLE
make api/username/ endpoint case insensitive

### DIFF
--- a/src/flick/flick_auth/controllers/check_username_controller.py
+++ b/src/flick/flick_auth/controllers/check_username_controller.py
@@ -14,6 +14,6 @@ class CheckUsernameController:
             return failure_response("Username must be 30 characters or less.")
         if len(username) < 3:
             return failure_response("Username must be at least three characters.")
-        if User.objects.filter(username=username):
+        if User.objects.filter(username__iexact=username):
             return failure_response("Username is already taken.")
         return success_response("Username is available!")

--- a/src/flick/flick_auth/controllers/update_profile_controller.py
+++ b/src/flick/flick_auth/controllers/update_profile_controller.py
@@ -2,6 +2,7 @@ from user.models import Profile
 
 from api.utils import failure_response
 from api.utils import success_response
+from django.contrib.auth.models import User
 
 
 class UpdateProfileController:
@@ -28,6 +29,10 @@ class UpdateProfileController:
         social_id_token_type = self._data.get("social_id_token_type")
 
         if username and self._user.username != username:
+            if len(username) > 30 or len(username) < 3:
+                return failure_response("Username must be between 3 and 30 characters.")
+            if User.objects.filter(username__iexact=username):
+                return failure_response("Username is already taken.")
             self._user.username = username
         if first_name and self._user.first_name != first_name:
             self._user.first_name = first_name


### PR DESCRIPTION
## Overview
I made username endpoint case insensitive and added username availability check when users update their own profiles

## Changes Made
- changed filter to be case insensitive
- added username availability check in UpdateProfileController

## Test Coverage
tested manually on postman
response when a username is taken
```
{
    "success": false,
    "error": "Username is already taken."
}
```

## Related PRs or Issues
closes #188 

