### PR TITLE
Add `/api/user/<id>/friends/` and update tests with redirect asserts

### DIFF
--- a/src/flick/api/tests.py
+++ b/src/flick/api/tests.py
@@ -5,6 +5,7 @@ import string
 from django.test import TestCase
 from django.test import TransactionTestCase
 from django.urls import reverse
+from friendship.exceptions import AlreadyFriendsError
 from friendship.models import Friend
 from rest_framework.test import APIClient
 
@@ -45,7 +46,10 @@ class FlickTestCase(TestCase):
         return token
 
     def _create_friendship(self, user1, user2):
-        Friend.objects.add_friend(user1, user2).accept()
+        try:
+            Friend.objects.add_friend(user1, user2).accept()
+        except AlreadyFriendsError:
+            return
 
 
 class FlickTransactionTestCase(TransactionTestCase):
@@ -84,4 +88,7 @@ class FlickTransactionTestCase(TransactionTestCase):
         return token
 
     def _create_friendship(self, user1, user2):
-        Friend.objects.add_friend(user1, user2).accept()
+        try:
+            Friend.objects.add_friend(user1, user2).accept()
+        except AlreadyFriendsError:
+            return

--- a/src/flick/api/tests.py
+++ b/src/flick/api/tests.py
@@ -5,6 +5,7 @@ import string
 from django.test import TestCase
 from django.test import TransactionTestCase
 from django.urls import reverse
+from friendship.models import Friend
 from rest_framework.test import APIClient
 
 
@@ -43,6 +44,9 @@ class FlickTestCase(TestCase):
         token = json.loads(response.content)["data"]["auth_token"]
         return token
 
+    def _create_friendship(self, user1, user2):
+        Friend.objects.add_friend(user1, user2).accept()
+
 
 class FlickTransactionTestCase(TransactionTestCase):
     AUTHENTICATE_URL = reverse("authenticate")
@@ -78,3 +82,6 @@ class FlickTransactionTestCase(TransactionTestCase):
         self.assertEqual(response.status_code, 200)
         token = json.loads(response.content)["data"]["auth_token"]
         return token
+
+    def _create_friendship(self, user1, user2):
+        Friend.objects.add_friend(user1, user2).accept()

--- a/src/flick/api/urls.py
+++ b/src/flick/api/urls.py
@@ -15,6 +15,7 @@ from friend.views import FriendList
 from friend.views import FriendRejectListAndCreate
 from friend.views import FriendRemoveListAndCreate
 from friend.views import FriendRequestListAndCreate
+from friend.views import UserFriendList
 from like.views import LikeView
 from lst.views import LstDetail
 from lst.views import LstDetailAdd
@@ -63,6 +64,7 @@ urlpatterns = [
     path("tags/", TagList.as_view(), name="tag-list"),
     path("tags/<int:pk>/", TagDetail.as_view(), name="tag-detail"),
     path("user/<int:pk>/", UserProfileView.as_view(), name="user-profile"),
+    path("user/<int:pk>/friends/", UserFriendList.as_view(), name="user-friend-list"),
     path("username/", CheckUsernameView.as_view(), name="check-username"),
     path("notifications/", NotificationList.as_view(), name="notif-list"),
 ]

--- a/src/flick/lst/tests/test_update_lst.py
+++ b/src/flick/lst/tests/test_update_lst.py
@@ -5,7 +5,6 @@ import string
 from api.tests import FlickTestCase
 from django.contrib.auth.models import User
 from django.urls import reverse
-from friendship.models import Friend
 from rest_framework.test import APIClient
 from show.models import Show
 from tag.models import Tag
@@ -55,9 +54,6 @@ class UpdateLstTests(FlickTestCase):
 
     def _get_created_tag_ids(self, num_tags):
         return [Tag.objects.create(name=self._get_random_string()).id for n in range(num_tags)]
-
-    def _create_friendship(self, user1, user2):
-        Friend.objects.add_friend(user1, user2).accept()
 
     def _create_list(self, collaborators=[], shows=[]):
         self.client.credentials(HTTP_AUTHORIZATION="Token " + self.user_token)

--- a/src/flick/notification/tests/test_list_invite_notification.py
+++ b/src/flick/notification/tests/test_list_invite_notification.py
@@ -3,7 +3,6 @@ import json
 from api.tests import FlickTestCase
 from django.contrib.auth.models import User
 from django.urls import reverse
-from friendship.models import Friend
 from rest_framework.test import APIClient
 
 
@@ -18,9 +17,6 @@ class ListInviteNotificationTests(FlickTestCase):
         self.user_token = self._create_user_and_login()
         self.friend_token = self._create_user_and_login()
         self._create_friendship(user1=User.objects.get(id=1), user2=User.objects.get(id=2))
-
-    def _create_friendship(self, user1, user2):
-        Friend.objects.add_friend(user1, user2).accept()
 
     def _create_list(self):
         self.client.credentials(HTTP_AUTHORIZATION="Token " + self.user_token)

--- a/src/flick/read/tests/test_read_tests.py
+++ b/src/flick/read/tests/test_read_tests.py
@@ -3,8 +3,6 @@ import json
 from api.tests import FlickTestCase
 from django.contrib.auth.models import User
 from django.urls import reverse
-from friendship.exceptions import AlreadyFriendsError
-from friendship.models import Friend
 from rest_framework.test import APIClient
 from show.models import Show
 
@@ -62,12 +60,6 @@ class ReadTests(FlickTestCase):
         comment = json.loads(response.content)["data"]["comments"][-1]
         self.assertEqual(response.status_code, 200)
         self.assertTrue(comment["is_readable"])
-
-    def _create_friendship(self, user1, user2):
-        try:
-            Friend.objects.add_friend(user1, user2).accept()
-        except AlreadyFriendsError:
-            return
 
     def _check_before_read(self, token):
         self.client.credentials(HTTP_AUTHORIZATION="Token " + token)

--- a/src/flick/search/tests/test_search_users.py
+++ b/src/flick/search/tests/test_search_users.py
@@ -3,8 +3,6 @@ import json
 from api.tests import FlickTestCase
 from django.contrib.auth.models import User
 from django.urls import reverse
-from friendship.exceptions import AlreadyFriendsError
-from friendship.models import Friend
 from rest_framework.test import APIClient
 
 
@@ -22,12 +20,6 @@ class SearchUsersTests(FlickTestCase):
         self.friend2 = User.objects.get(id=3)
         # user and friend3 should have one mutual friend: friend1
         self.friend3 = User.objects.get(id=4)
-
-    def _create_friendship(self, user1, user2):
-        try:
-            Friend.objects.add_friend(user1, user2).accept()
-        except AlreadyFriendsError:
-            return
 
     # Known to fail when running `python manage.py test` likely due to concurrency
     def test_search_user(self):

--- a/src/flick/show/tests/test_show_rating_comment.py
+++ b/src/flick/show/tests/test_show_rating_comment.py
@@ -3,8 +3,6 @@ import json
 from api.tests import FlickTestCase
 from django.contrib.auth.models import User
 from django.urls import reverse
-from friendship.exceptions import AlreadyFriendsError
-from friendship.models import Friend
 from rest_framework.test import APIClient
 from show.models import Show
 
@@ -63,12 +61,6 @@ class ShowRatingsAndCommentTests(FlickTestCase):
         comment = json.loads(response.content)["data"]["comments"][-1]
         self.assertEqual(response.status_code, 200)
         self.assertEqual(comment["message"], comment_data.get("comment").get("message"))
-
-    def _create_friendship(self, user1, user2):
-        try:
-            Friend.objects.add_friend(user1, user2).accept()
-        except AlreadyFriendsError:
-            return
 
     def _check_friends_rating(self, rating):
         self.client.credentials(HTTP_AUTHORIZATION="Token " + self.user_token)

--- a/src/flick/suggestion/tests/test_private_suggestion.py
+++ b/src/flick/suggestion/tests/test_private_suggestion.py
@@ -3,8 +3,6 @@ import json
 from api.tests import FlickTestCase
 from django.contrib.auth.models import User
 from django.urls import reverse
-from friendship.exceptions import AlreadyFriendsError
-from friendship.models import Friend
 from rest_framework.test import APIClient
 from show.models import Show
 
@@ -48,12 +46,6 @@ class PrivateSuggestionTests(FlickTestCase):
         self.assertEqual(len(data), 2)
         self.assertEqual(data[-1]["show"]["id"], suggest_data.get("show_id"))
         self.assertEqual(data[-1]["message"], suggest_data.get("message"))
-
-    def _create_friendship(self, user1, user2):
-        try:
-            Friend.objects.add_friend(user1, user2).accept()
-        except AlreadyFriendsError:
-            return
 
     def _check_suggestion(self, friend_token, suggest_data):
         self.client.credentials(HTTP_AUTHORIZATION="Token " + friend_token)

--- a/src/flick/user/tests/test_user_friends.py
+++ b/src/flick/user/tests/test_user_friends.py
@@ -1,0 +1,48 @@
+import json
+
+from api.tests import FlickTestCase
+from django.contrib.auth.models import User
+from django.urls import reverse
+from rest_framework.test import APIClient
+
+
+class UserFriendsTests(FlickTestCase):
+    FRIEND1_ID = 1  # friend1 and friend2 are friends
+    FRIEND2_ID = 2
+    USER_ID = 3  # user should see that they are friends
+
+    FRIEND_LIST_URL = reverse("friend-list")
+
+    def setUp(self):
+        self.client = APIClient()
+        self.friend1_token = self._create_user_and_login()
+        self.friend2_token = self._create_user_and_login()
+        self.user_token = self._create_user_and_login()
+
+    def _friend_list_url(self, id):
+        return reverse("user-friend-list", kwargs={"pk": id})
+
+    def test_user_sees_friends_of_friend1_and_friend2(self):
+        self._create_friendship(User.objects.get(id=self.FRIEND1_ID), User.objects.get(id=self.FRIEND2_ID))
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.user_token)
+        response = self.client.get(self._friend_list_url(self.FRIEND1_ID))
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.content)["data"][0]
+        self.assertEqual(data.get("id"), self.FRIEND2_ID)
+
+        response = self.client.get(self._friend_list_url(self.FRIEND2_ID))
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.content)["data"][0]
+        self.assertEqual(data.get("id"), self.FRIEND1_ID)
+
+    def test_redirects_to_friend_list(self):
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.user_token)
+        response = self.client.get(self._friend_list_url(self.USER_ID))
+        self.assertRedirects(
+            response,
+            self.FRIEND_LIST_URL,
+            status_code=302,
+            target_status_code=200,
+            msg_prefix="",
+            fetch_redirect_response=True,
+        )

--- a/src/flick/user/tests/test_user_profile.py
+++ b/src/flick/user/tests/test_user_profile.py
@@ -62,3 +62,10 @@ class UserProfileTests(FlickTestCase):
         Friend.objects.remove_friend(from_user, to_user)
         self._check_friend_status(self.user_token, self.RANDO_PROFILE_URL, self.RANDO_ID, "not friends")
         self._check_friend_status(self.rando_token, self.USER_PROFILE_URL, self.USER_ID, "not friends")
+
+    def test_view_own_profile_redirects(self):
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.user_token)
+        response = self.client.get(self.USER_PROFILE_URL)
+        self.assertRedirects(
+            response, self.ME_URL, status_code=302, target_status_code=200, msg_prefix="", fetch_redirect_response=True
+        )


### PR DESCRIPTION
## Overview
We want to be able to see the list of friends for a given user! If you accidentally enter your own `user_id`, we redirect you to http://localhost:8000/api/friends/ (status code is 302, but landing redirect status code is 200 and the response still has `"success": true, "data": ...`

## Example
**GET http://localhost:8000/api/user/4/friends/**
Response Body:
```
{
    "success": true,
    "data": [
        {
            "username": "alannazhou3",
            "id": 3,
            "name": "alanna",
            "bio": null,
            "profile_pic": "base 64 string"
        }
    ]
}
```

## Changes Made
* Add new endpoint
* Clean up tests by refactoring `_create_friendship()` into `FlickTestCase` and `FlickTransactionTestCase`
* Add redirect testing, I remember @ViviYe said she had issues testing the redirect for `reverse("user-profile")` to `reverse("me")`, but I found that it's actually quite an easy assertion:
```
self.assertRedirects(
            response, self.ME_URL, status_code=302, target_status_code=200, msg_prefix="", fetch_redirect_response=True
        )
```

## Test Coverage
All tests pass except for expected 3 flaky ones:
```
----------------------------------------------------------------------
Ran 46 tests in 21.663s

FAILED (failures=3)
Destroying test database for alias 'default'...
```

## Related PRs or Issues
Closes #213 