### PR TITLE
Add movie and tv combined search

### DIFF
--- a/src/flick/api/tests.py
+++ b/src/flick/api/tests.py
@@ -12,7 +12,7 @@ from rest_framework.test import APIClient
 
 class FlickTestCase(TestCase):
     AUTHENTICATE_URL = reverse("authenticate")
-    NAME = "Alanna Zhou"
+    NAME = "alanna zhou"
 
     def get_random_str(self):
         letters = string.digits
@@ -54,7 +54,7 @@ class FlickTestCase(TestCase):
 
 class FlickTransactionTestCase(TransactionTestCase):
     AUTHENTICATE_URL = reverse("authenticate")
-    NAME = "Alanna Zhou"
+    NAME = "alanna zhou"
 
     def get_random_str(self):
         letters = string.digits

--- a/src/flick/search/views.py
+++ b/src/flick/search/views.py
@@ -54,17 +54,13 @@ class Search(APIView):
 
     def get_shows_by_query(self, query, is_movie, is_tv, is_multi, is_anime, page=1, tags=[]):
         if is_multi:
-            print("Is multi")
             self.get_shows_by_type_and_query(query, "multi", "tmdb", page, tags)
             return
         if is_movie:
-            print("is movie")
             self.get_shows_by_type_and_query(query, "movie", "tmdb", page, tags)
         if is_tv:
-            print("is tv")
             self.get_shows_by_type_and_query(query, "tv", "tmdb", page, tags)
         if is_anime:
-            print("is anime")
             self.get_shows_by_type_and_query(query, "anime", "animelist")
 
     def get_users_by_username(self, query):
@@ -93,7 +89,6 @@ class Search(APIView):
         is_lst = bool(request.query_params.get("is_lst", False))
         is_tag = bool(request.query_params.get("is_tag", False))
         is_multi = bool(request.query_params.get("is_multi", False))
-        print("is_multi", is_multi)
 
         self.shows = []
         self.known_shows = []

--- a/src/flick/search/views.py
+++ b/src/flick/search/views.py
@@ -52,12 +52,19 @@ class Search(APIView):
             local_cache.set((query, show_type, tags), shows)
         self.shows.extend(shows)
 
-    def get_shows_by_query(self, query, is_movie, is_tv, is_anime, page=1, tags=[]):
+    def get_shows_by_query(self, query, is_movie, is_tv, is_multi, is_anime, page=1, tags=[]):
+        if is_multi:
+            print("Is multi")
+            self.get_shows_by_type_and_query(query, "multi", "tmdb", page, tags)
+            return
         if is_movie:
+            print("is movie")
             self.get_shows_by_type_and_query(query, "movie", "tmdb", page, tags)
         if is_tv:
+            print("is tv")
             self.get_shows_by_type_and_query(query, "tv", "tmdb", page, tags)
         if is_anime:
+            print("is anime")
             self.get_shows_by_type_and_query(query, "anime", "animelist")
 
     def get_users_by_username(self, query):
@@ -85,6 +92,8 @@ class Search(APIView):
         is_user = bool(request.query_params.get("is_user", False))
         is_lst = bool(request.query_params.get("is_lst", False))
         is_tag = bool(request.query_params.get("is_tag", False))
+        is_multi = bool(request.query_params.get("is_multi", False))
+        print("is_multi", is_multi)
 
         self.shows = []
         self.known_shows = []
@@ -96,7 +105,7 @@ class Search(APIView):
         elif is_tag:
             return success_response_with_query(query=query, data=self.get_tags_by_name(query))
         else:
-            self.get_shows_by_query(query, is_movie, is_tv, is_anime, page, tags)
+            self.get_shows_by_query(query, is_movie, is_tv, is_multi, is_anime, page, tags)
 
         serializer_data = []
         serializer_data.extend(ShowAPI.create_show_objects(self.shows))

--- a/src/flick/show/show_api_utils.py
+++ b/src/flick/show/show_api_utils.py
@@ -96,6 +96,8 @@ class ShowAPI:
             return flicktmdb().search_show(query=name, page=page, tags=tags, is_tv=False)
         elif show_type == "tv":
             return flicktmdb().search_show(query=name, page=page, tags=tags, is_tv=True)
+        elif show_type == "multi":
+            return flicktmdb().search_general_show(query=name, page=page, tags=tags)
         if show_type == "anime":
             return AnimeList_API().search_anime_by_name(name=name, page=page)
         return None

--- a/src/flick/show/tmdb.py
+++ b/src/flick/show/tmdb.py
@@ -120,3 +120,34 @@ class flicktmdb:
             }
             shows.append(show)
         return shows
+
+    def search_general_show(self, query, page=1, tags=[]):
+        """Includes movies and tv."""
+        url = f"{settings.TMDB_BASE_URL}/search/multi?query={query}&page={page}&api_key={settings.TMDB_API_KEY}"
+        r = requests.get(url)
+        if r.status_code != 200:
+            return []
+        results = json.loads(r.content).get("results")
+        shows = []
+        for result in results:
+            if result.get("media_type") not in ["tv", "movie"]:
+                continue
+            if not set(tags).issubset(set(result.get("genre_ids"))):
+                continue
+            backdrop_path = result.get("backdrop_path")
+            poster_path = result.get("poster_path")
+            is_tv = True if result.get("media_type") == "tv" else False
+            show = {
+                "backdrop_pic": settings.TMDB_BASE_IMAGE_URL + backdrop_path if backdrop_path else None,
+                "date_released": result.get("first_air_date" if is_tv else "release_date"),
+                "ext_api_id": result.get("id"),
+                "ext_api_source": "tmdb",
+                "is_adult": result.get("adult"),
+                "is_tv": is_tv,
+                "language": result.get("original_language"),
+                "plot": result.get("overview"),
+                "poster_pic": settings.TMDB_BASE_IMAGE_URL + poster_path if poster_path else None,
+                "title": result.get("name" if is_tv else "title"),
+            }
+            shows.append(show)
+        return shows


### PR DESCRIPTION
## Overview
@haiyingweng found that when searching by is_movie=true and is_tv=true, tv shows after movies (Ex: searching Friends)
* Added a new query param: `is_multi`
* `tags`, `page`, `query` all work with this
* can't add is_tv or is_movie or is_anime or is_top with this, if you use is_multi you should only use is_multi (i can't guarantee other stuff)

## Example
GET http://localhost:8000/api/search/?is_multi=True&page=1&query=friends
will give you a mix of tv and show (first result is Friends tv show!)

## Changes Made
Also fixed username tests for when i changed to lowercase

## Test Coverage
All tests pass

## Related PRs or Issues
Closes #224