### PR TITLE
Add search users by name and username

### DIFF
--- a/src/flick/search/views.py
+++ b/src/flick/search/views.py
@@ -64,7 +64,8 @@ class Search(APIView):
             self.get_shows_by_type_and_query(query, "anime", "animelist")
 
     def get_users_by_username(self, query):
-        users = User.objects.filter(Q(username__icontains=query) & Q(is_superuser=False))
+        non_superusers = User.objects.filter(Q(is_superuser=False))
+        users = non_superusers.filter(Q(first_name__icontains=query) | Q(username__icontains=query))
         serializer = UserSimpleSerializer(instance=users, many=True, context={"request": self.request})
         return serializer.data
 


### PR DESCRIPTION
## Overview
Added search by name. Right now we only do search by username, now if either username or name has the query as a substring (case insensitive), we will return that user in the search.

**GET /api/search/?is_user=true&query=w**
Response Body
```
{
    "success": true,
    "query": "w",
    "data": [
        {
            "id": 1,
            "username": "haiyingweng",
            "name": "Haiying Weng",
            "profile_pic": "",
            "num_mutual_friends": 0
        },
        {
            "id": 4,
            "username": "asss",
            "name": "Alannaw",
            "profile_pic": "",
            "num_mutual_friends": 0
        }
    ]
}
```

## Test Coverage
Tests pass


## Related PRs or Issues
Closes #228