### PR TITLE
Friends in profile

### DIFF
--- a/src/flick/user/serializers.py
+++ b/src/flick/user/serializers.py
@@ -49,7 +49,7 @@ class ProfileSerializer(serializers.ModelSerializer):
     # profile_pic = AssetBundleDetailSerializer(source="profile_asset_bundle")
     owner_lsts = MeLstSerializer(many=True)
     collab_lsts = MeLstSerializer(many=True)
-    user_friends = serializers.SerializerMethodField("get_friends_profiles")
+    friends = serializers.SerializerMethodField("get_friends_profiles")
 
     def get_friends_profiles(self, profile):
         friends = [User.objects.get(id=friend.id) for friend in Friend.objects.friends(user=profile.user)]
@@ -71,7 +71,7 @@ class ProfileSerializer(serializers.ModelSerializer):
             "num_notifs",
             "owner_lsts",
             "collab_lsts",
-            "user_friends",
+            "friends",
         )
         read_only_fields = fields
 

--- a/src/flick/user/serializers.py
+++ b/src/flick/user/serializers.py
@@ -51,9 +51,9 @@ class ProfileSerializer(serializers.ModelSerializer):
     collab_lsts = MeLstSerializer(many=True)
     user_friends = serializers.SerializerMethodField("get_friend_profiles")
 
-    def get_friend_profiles(self, profile):
+    def get_friends_profiles(self, profile):
         friends = [User.objects.get(id=friend.id) for friend in Friend.objects.friends(user=profile.user)]
-        return FriendUserSerializer(friends, many=True).data
+        return FriendUserSerializer(friends[:7], many=True).data
 
     class Meta:
         model = Profile

--- a/src/flick/user/serializers.py
+++ b/src/flick/user/serializers.py
@@ -2,6 +2,7 @@ from user.models import Profile
 
 from django.contrib.auth.models import User
 from django.db.models import Q
+from friend.serializers import FriendUserSerializer
 from friendship.models import Friend
 from lst.simple_serializers import MeLstSerializer
 from rest_framework import serializers
@@ -48,6 +49,11 @@ class ProfileSerializer(serializers.ModelSerializer):
     # profile_pic = AssetBundleDetailSerializer(source="profile_asset_bundle")
     owner_lsts = MeLstSerializer(many=True)
     collab_lsts = MeLstSerializer(many=True)
+    user_friends = serializers.SerializerMethodField("get_friend_profiles")
+
+    def get_friend_profiles(self, profile):
+        friends = [User.objects.get(id=friend.id) for friend in Friend.objects.friends(user=profile.user)]
+        return FriendUserSerializer(friends, many=True).data
 
     class Meta:
         model = Profile
@@ -65,6 +71,7 @@ class ProfileSerializer(serializers.ModelSerializer):
             "num_notifs",
             "owner_lsts",
             "collab_lsts",
+            "user_friends",
         )
         read_only_fields = fields
 

--- a/src/flick/user/serializers.py
+++ b/src/flick/user/serializers.py
@@ -49,7 +49,7 @@ class ProfileSerializer(serializers.ModelSerializer):
     # profile_pic = AssetBundleDetailSerializer(source="profile_asset_bundle")
     owner_lsts = MeLstSerializer(many=True)
     collab_lsts = MeLstSerializer(many=True)
-    user_friends = serializers.SerializerMethodField("get_friend_profiles")
+    user_friends = serializers.SerializerMethodField("get_friends_profiles")
 
     def get_friends_profiles(self, profile):
         friends = [User.objects.get(id=friend.id) for friend in Friend.objects.friends(user=profile.user)]


### PR DESCRIPTION
## Overview
make profiles include information about friends(up to 7, not necessarily the most recent ones).

## Changes Made
- added get_user_friend to profile serializer

## Test Coverage
tested manually and passes test cases 

## Next Step
if needed, I can update the 7 friends to be the most recent ones

## Related PRs or Issues
closes #231 
