### PR TITLE
Fix duplicate and outgoing accepted friend request notifications

### DIFF
--- a/src/flick/friend/views.py
+++ b/src/flick/friend/views.py
@@ -106,10 +106,10 @@ class FriendAcceptListAndCreate(generics.ListCreateAPIView):
         notif.from_user = to_profile
         notif.to_user = from_profile
         notif.save()
-        ios_devices = APNSDevice.objects.filter(user=to_user, active=True)
-        android_devices = GCMDevice.objects.filter(user=to_user, active=True)
+        ios_devices = APNSDevice.objects.filter(user=from_user, active=True)
+        android_devices = GCMDevice.objects.filter(user=from_user, active=True)
         message_body = (
-            f"({to_user.username}): {from_user.first_name} (@{from_user.username}) accepted your friend request."
+            f"({from_user.username}): {to_user.first_name} (@{to_user.username}) accepted your friend request."
         )
         ios_devices.send_message(message={"body": message_body})
         android_devices.send_message(message={"body": message_body})


### PR DESCRIPTION
## Overview
The error is
<img src="https://user-images.githubusercontent.com/13739525/105639259-fe6b9480-5e2b-11eb-889d-466399d1599c.png" width="250"/>

## Changes Made
* Check if a device already exists, if so use that and make it active, otherwise create a new device and make it active too (at `/api/notifications/enable/`)

## Test Coverage
All tests pass (although it's not saying much)
```
(venv) ~/D/f/s/flick ❯❯❯ python manage.py test --exclude-tag=flakey
Creating test database for alias 'default'...
System check identified no issues (0 silenced).
.......................................
----------------------------------------------------------------------
Ran 39 tests in 9.428s

OK
Destroying test database for alias 'default'...
```

## Next Steps
Add suggestion notif #245

## Related PRs or Issues
#237 