### PR TITLE
Speed /me by 2x 

### DIFF
--- a/src/flick_auth/views.py
+++ b/src/flick_auth/views.py
@@ -26,7 +26,16 @@ class UserView(generics.GenericAPIView):
     permission_classes = api_settings.CONSUMER_PERMISSIONS
 
     def get(self, request):
-        profile = Profile.objects.get(user=self.request.user)
+        profile = Profile.objects.filter(user=self.request.user).prefetch_related(
+            "owner_lsts",
+            "collab_lsts",
+            "owner_lsts__owner",
+            "owner_lsts__collaborators",
+            "owner_lsts__shows",
+            "collab_lsts__owner",
+            "collab_lsts__collaborators",
+            "collab_lsts__shows",
+        )[0]
         serializer = self.serializer_class(profile)
         return success_response(serializer.data)
 


### PR DESCRIPTION
## Overview
Use `prefetch_related` to optimize our nested django serializer queries~

## Proof 1
When using vivi's user on the app, we get
```
In [5]: p = Profile.objects.filter(user__id=11).prefetch_related(
   ...:             "owner_lsts",
   ...:             "collab_lsts",
   ...:             "owner_lsts__owner",
   ...:             "owner_lsts__collaborators",
   ...:             "owner_lsts__shows",
   ...:             "collab_lsts__owner",
   ...:             "collab_lsts__collaborators",
   ...:             "collab_lsts__shows",
   ...:         )[0]

In [6]: p_slow = Profile.objects.filter(user__id=11)[0]
In [21]: start_time = time.time()
    ...: ProfileSerializer(p).data
    ...: print("--- %s seconds ---" % (time.time() - start_time))
--- 2.116029739379883 seconds ---

In [22]: start_time = time.time()
    ...: ProfileSerializer(p_slow).data
    ...: print("--- %s seconds ---" % (time.time() - start_time))
--- 4.063729286193848 seconds ---
```

## Proof 2
When testing on our user `teliebuddies`, we get
```
In [24]: p = Profile.objects.filter(user__username="teliebuddies").prefetch_related(
    ...:             "owner_lsts",
    ...:             "collab_lsts",
    ...:             "owner_lsts__owner",
    ...:             "owner_lsts__collaborators",
    ...:             "owner_lsts__shows",
    ...:             "collab_lsts__owner",
    ...:             "collab_lsts__collaborators",
    ...:             "collab_lsts__shows",
    ...:         )[0]

In [25]: p_slow = Profile.objects.filter(user__username="teliebuddies")[0]

In [26]: start_time = time.time()
    ...: ProfileSerializer(p).data
    ...: print("--- %s seconds ---" % (time.time() - start_time))
--- 1.4563939571380615 seconds ---

In [27]: start_time = time.time()
    ...: ProfileSerializer(p_slow).data
    ...: print("--- %s seconds ---" % (time.time() - start_time))
--- 2.485239028930664 seconds ---
```

## Changes Made
The idea is that we don't want to make multiple trips to the database for each list on the profile -- we want to make 1 trip to fetch all of the shows


## Test Coverage
Works in my shell

## Next Steps
Add more `prefetch_related` to other queries

## Related PRs or Issues
#294