### PR TITLE
Make notifs + suggestions faster and add group remove endpoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,5 @@ RUN pip3 install --no-cache-dir -r requirements.txt
 
 EXPOSE 8000
 
-CMD ["gunicorn", "flick.wsgi", "0:8000"]
+# CMD ["gunicorn", "flick.wsgi", "0:8000"]
+CMD ["uvicorn", "flick.asgi:application"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -55,6 +55,7 @@ sqlparse==0.4.1
 toml==0.10.2
 typing-extensions==3.7.4.3
 urllib3>=1.21.1
+uvicorn==0.13.4
 vine>=1.3.0
 virtualenv==20.4.0
 wcwidth==0.2.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -62,4 +62,4 @@ wcwidth==0.2.5
 yarl==1.6.3
 zipp==3.4.0
 tmdbsimple==2.2.15
-qinspect==1.1.0
+django-queryinspect==1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -62,4 +62,4 @@ wcwidth==0.2.5
 yarl==1.6.3
 zipp==3.4.0
 tmdbsimple==2.2.15
-
+qinspect==1.1.0

--- a/src/api/urls.py
+++ b/src/api/urls.py
@@ -5,6 +5,7 @@ from asset.views import AssetBundleList
 from discover.views import DiscoverView
 from django.urls import include
 from django.urls import path
+from flick_auth.async_views import index
 from flick_auth.views import AuthenticateView
 from flick_auth.views import CheckUsernameView
 from flick_auth.views import LogoutView
@@ -51,6 +52,7 @@ router.register(r"users", UserViewSet)
 router.register(r"shows", ShowViewSet)
 
 urlpatterns = [
+    path("async/", index, name="async"),
     path("", include(router.urls)),
     path("api-auth/", include("rest_framework.urls", namespace="rest_framework")),
     path("asset-bundles/", AssetBundleList.as_view(), name="asset-bundles-list"),

--- a/src/comment/serializers.py
+++ b/src/comment/serializers.py
@@ -1,4 +1,3 @@
-from user.models import Profile
 from user.profile_simple_serializers import ProfileSimpleSerializer
 
 from rest_framework import serializers
@@ -20,23 +19,16 @@ class CommentSerializer(serializers.ModelSerializer):
 
     def get_has_liked(self, instance):
         request = self.context.get("request")
-        user = request.user
-
-        profile = Profile.objects.get(user=user)
-
-        has_liked = instance.likers.filter(liker=profile).exists()
+        has_liked = instance.likers.filter(liker=request.user.profile).exists()
         return has_liked
 
     def get_is_readable(self, instance):
         if not instance.is_spoiler:
             return True
         request = self.context.get("request")
-        user = request.user
-
-        profile = Profile.objects.get(user=user)
+        profile = request.user.profile
         if instance.owner == profile:
             return True
-
         is_readable = instance.reads.filter(reader=profile).exists()
         return is_readable
 

--- a/src/flick/settings.py
+++ b/src/flick/settings.py
@@ -77,6 +77,7 @@ MIDDLEWARE = [
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
+    "qinspect.middleware.QueryInspectMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
@@ -132,6 +133,64 @@ AUTH_PASSWORD_VALIDATORS = [
     {"NAME": "django.contrib.auth.password_validation.NumericPasswordValidator"},
 ]
 
+# Whether the Query Inspector should do anything (default: False)
+QUERY_INSPECT_ENABLED = True
+# Whether to log the stats via Django logging (default: True)
+QUERY_INSPECT_LOG_STATS = True
+# Whether to add stats headers (default: True)
+QUERY_INSPECT_HEADER_STATS = True
+# Whether to log duplicate queries (default: False)
+QUERY_INSPECT_LOG_QUERIES = True
+# Whether to log queries that are above an absolute limit (default: None - disabled)
+QUERY_INSPECT_ABSOLUTE_LIMIT = 100  # in milliseconds
+# Whether to log queries that are more than X standard deviations above the mean query time (default: None - disabled)
+QUERY_INSPECT_STANDARD_DEVIATION_LIMIT = 2
+# Whether to include tracebacks in the logs (default: False)
+# QUERY_INSPECT_LOG_TRACEBACKS = True
+# Project root (a list of directories, see below - default empty)
+# QUERY_INSPECT_TRACEBACK_ROOTS = ["/path/to/my/django/project/"]
+# Minimum number of duplicates needed to log the query (default: 2)
+QUERY_INSPECT_DUPLICATE_MIN = 1  # to force logging of all queries
+# Whether to truncate SQL queries in logs to specified size, for readability purposes (default: None - full SQL query is included)
+QUERY_INSPECT_SQL_LOG_LIMIT = 120  # limit to 120 chars
+
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": True,
+    "formatters": {
+        "verbose": {"format": "%(levelname)s %(asctime)s %(module)s %(process)d %(thread)d %(message)s"},
+        "simple": {"format": "%(levelname)s %(message)s"},
+    },
+    "handlers": {
+        "null": {
+            "level": "DEBUG",
+            "class": "logging.NullHandler",
+        },
+        "console": {"level": "DEBUG", "class": "logging.StreamHandler", "formatter": "simple"},
+        "mail_admins": {
+            "level": "ERROR",
+            "class": "django.utils.log.AdminEmailHandler",
+            "filters": [],
+        },
+    },
+    "loggers": {
+        "django": {
+            "handlers": ["null"],
+            "propagate": True,
+            "level": "INFO",
+        },
+        "django.request": {
+            "handlers": ["mail_admins"],
+            "level": "ERROR",
+            "propagate": False,
+        },
+        "qinspect": {
+            "handlers": ["console"],
+            "level": "DEBUG",
+            "propagate": True,
+        },
+    },
+}
 
 # Internationalization
 # https://docs.djangoproject.com/en/2.1/topics/i18n/

--- a/src/flick/settings.py
+++ b/src/flick/settings.py
@@ -146,9 +146,9 @@ QUERY_INSPECT_ABSOLUTE_LIMIT = 100  # in milliseconds
 # Whether to log queries that are more than X standard deviations above the mean query time (default: None - disabled)
 QUERY_INSPECT_STANDARD_DEVIATION_LIMIT = 2
 # Whether to include tracebacks in the logs (default: False)
-# QUERY_INSPECT_LOG_TRACEBACKS = True
+QUERY_INSPECT_LOG_TRACEBACKS = True
 # Project root (a list of directories, see below - default empty)
-# QUERY_INSPECT_TRACEBACK_ROOTS = ["/path/to/my/django/project/"]
+QUERY_INSPECT_TRACEBACK_ROOTS = ["."]
 # Minimum number of duplicates needed to log the query (default: 2)
 QUERY_INSPECT_DUPLICATE_MIN = 1  # to force logging of all queries
 # Whether to truncate SQL queries in logs to specified size, for readability purposes (default: None - full SQL query is included)

--- a/src/flick_auth/async_views.py
+++ b/src/flick_auth/async_views.py
@@ -1,0 +1,5 @@
+from django.http import HttpResponse
+
+
+async def index(request):
+    return HttpResponse("Hello, async Django!")

--- a/src/group/views.py
+++ b/src/group/views.py
@@ -62,6 +62,11 @@ class GroupDetail(generics.GenericAPIView):
     serializer_class = GroupSerializer
     permission_classes = api_settings.CONSUMER_PERMISSIONS
 
+    def delete(self, request, pk):
+        """Remove a group by id."""
+        request.user.profile.groups.get(id=pk).delete()
+        return success_response(f"Group with id {pk} has been deleted.")
+
     def get(self, request, pk):
         """Get a group by id. If request.user does not belong to the group, return a failure response."""
         profile = Profile.objects.get(user=request.user)
@@ -93,6 +98,8 @@ class GroupDetailAdd(generics.GenericAPIView):
         member_ids = data.get("members", [])
         show_ids = data.get("shows", [])
         num_random_shows = data.get("num_random_shows", 0)
+        #  group.members.add(*Profile.objects.filter(user__id_in=member_ids))
+        # group.shows.add(*Show.objects.filter(id__in=show_ids))
         for member_id in member_ids:
             try:
                 member_profile = Profile.objects.get(user__id=member_id)

--- a/src/group/views.py
+++ b/src/group/views.py
@@ -98,21 +98,8 @@ class GroupDetailAdd(generics.GenericAPIView):
         member_ids = data.get("members", [])
         show_ids = data.get("shows", [])
         num_random_shows = data.get("num_random_shows", 0)
-        #  group.members.add(*Profile.objects.filter(user__id_in=member_ids))
-        # group.shows.add(*Show.objects.filter(id__in=show_ids))
-        for member_id in member_ids:
-            try:
-                member_profile = Profile.objects.get(user__id=member_id)
-                group.members.add(member_profile)
-            except:
-                continue
-        for show_id in show_ids:
-            try:
-                show = Show.objects.get(id=show_id)
-                group.shows.add(show)
-            except:
-                continue
-
+        group.members.add(*Profile.objects.filter(user__id_in=member_ids))
+        group.shows.add(*Show.objects.filter(id__in=show_ids))
         rec_shows = []
         if num_random_shows > 0:
             show_lst = []

--- a/src/notification/views.py
+++ b/src/notification/views.py
@@ -4,7 +4,6 @@ from user.models import Profile
 from api import settings as api_settings
 from api.utils import failure_response
 from api.utils import success_response
-from django.db.models import Q
 from django.utils.dateparse import parse_datetime
 from notification.models import Notification
 from notification.serializers import NotificationSerializer
@@ -21,15 +20,14 @@ class NotificationList(generics.GenericAPIView):
 
     def get(self, request):
         """See all notifications."""
-        profile = Profile.objects.get(user=request.user)
-        notifs = Notification.objects.filter(Q(to_user=profile)).prefetch_related(
+        notifs = Notification.objects.filter(to_user__user=request.user).prefetch_related(
             "from_user",
             "to_user",
             "lst",
             "group",
-            "group__members",
+            # "group__members", not in supersimpleserializer
             "comment",
-            "comment__owner",
+            # "comment__owner", makes 13 to 12 duplicates for some reason
             "comment__show",
             "suggestion",
             "suggestion__to_user",

--- a/src/notification/views.py
+++ b/src/notification/views.py
@@ -25,9 +25,7 @@ class NotificationList(generics.GenericAPIView):
             "to_user",
             "lst",
             "group",
-            # "group__members", not in supersimpleserializer
             "comment",
-            # "comment__owner", makes 13 to 12 duplicates for some reason
             "comment__show",
             "suggestion",
             "suggestion__to_user",

--- a/src/suggestion/serializers.py
+++ b/src/suggestion/serializers.py
@@ -1,4 +1,3 @@
-from user.models import Profile
 from user.profile_simple_serializers import ProfileSimpleSerializer
 
 from rest_framework import serializers
@@ -22,9 +21,7 @@ class PrivateSuggestionSerializer(serializers.ModelSerializer):
 
     def get_has_liked(self, instance):
         request = self.context.get("request")
-        user = request.user
-        profile = Profile.objects.get(user=user)
-        has_liked = instance.likers.filter(liker=profile).exists()
+        has_liked = instance.likers.filter(liker__user=request.user).exists()
         return has_liked
 
 

--- a/src/suggestion/views.py
+++ b/src/suggestion/views.py
@@ -26,9 +26,7 @@ class SuggestionList(generics.GenericAPIView):
 
     def get(self, request):
         """See all suggestions."""
-        user = request.user
-        profile = Profile.objects.get(user=user)
-        suggestions = profile.suggestions_received.all().prefetch_related("to_user", "from_user", "show")
+        suggestions = request.user.profile.suggestions_received.all().prefetch_related("from_user", "show")
         suggestion_data = PrivateSuggestionSerializer(suggestions, context={"request": request}, many=True)
         return success_response(suggestion_data.data)
 


### PR DESCRIPTION
## Overview
* Make notifs faster
```
BEFORE: INFO [SQL] 30 queries (13 duplicates), 3977 ms SQL time, 4638 ms total request time
AFTER: INFO [SQL] 28 queries (12 duplicates), 3260 ms SQL time, 4032 ms total request time
```
* Make suggestions faster
```
BEFORE: INFO [SQL] 20 queries (13 duplicates), 2076 ms SQL time, 2676 ms total request time
AFTER: INFO [SQL] 13 queries (6 duplicates), 1497 ms SQL time, 2075 ms total request time
```
* Add group delete endpoint at `DELETE /api/groups/<id>/`
```
{
    "success": true,
    "data": "Group with id 37 has been deleted."
}
```


## Changes Made
@olivialy524 @ViviYe it's faster / less expensive to use 
```
SomeObject.filter(profile__user=request.user)
``` 
than do 
```
profile = Profile.objects.get(user=request.user)
SomeObject.filter(profile=profile)
```
## Related PRs or Issues
#297 #253 