### PR TITLE
move add shows to be separated endpoints

### DIFF
--- a/src/api/urls.py
+++ b/src/api/urls.py
@@ -19,11 +19,13 @@ from friend.views import FriendRequestListAndCreate
 from friend.views import UserFriendList
 from group.views import GroupClearShows
 from group.views import GroupDetail
-from group.views import GroupDetailAdd
-from group.views import GroupDetailRemove
 from group.views import GroupList
+from group.views import GroupMembersAdd
+from group.views import GroupMembersRemove
 from group.views import GroupPendingList
 from group.views import GroupShowList
+from group.views import GroupShowsAdd
+from group.views import GroupShowsRemove
 from group.views import GroupVoteShow
 from like.views import LikeView
 from like.views import LstLikeView
@@ -69,8 +71,10 @@ urlpatterns = [
     path("friends/remove/", FriendRemoveListAndCreate.as_view(), name="friend-remove"),
     path("groups/", GroupList.as_view(), name="group-list"),
     path("groups/<int:pk>/", GroupDetail.as_view(), name="group-detail"),
-    path("groups/<int:pk>/add/", GroupDetailAdd.as_view(), name="group-detail-add"),
-    path("groups/<int:pk>/remove/", GroupDetailRemove.as_view(), name="group-detail-remove"),
+    path("groups/<int:pk>/members/add/", GroupMembersAdd.as_view(), name="group-members-add"),
+    path("groups/<int:pk>/members/remove/", GroupMembersRemove.as_view(), name="group-members-remove"),
+    path("groups/<int:pk>/shows/add/", GroupShowsAdd.as_view(), name="group-shows-add"),
+    path("groups/<int:pk>/shows/remove/", GroupShowsRemove.as_view(), name="group-shows-remove"),
     path("groups/<int:pk>/pending/", GroupPendingList.as_view(), name="group-pending-list"),
     path("groups/<int:pk>/shows/", GroupShowList.as_view(), name="group-show-list"),
     path("groups/<int:pk>/shows/clear/", GroupClearShows.as_view(), name="group-clear-shows"),

--- a/src/api/urls.py
+++ b/src/api/urls.py
@@ -19,6 +19,8 @@ from friend.views import FriendRequestListAndCreate
 from friend.views import UserFriendList
 from group.views import GroupClearShows
 from group.views import GroupDetail
+from group.views import GroupDetailAdd
+from group.views import GroupDetailRemove
 from group.views import GroupList
 from group.views import GroupMembersAdd
 from group.views import GroupMembersRemove
@@ -71,6 +73,8 @@ urlpatterns = [
     path("friends/remove/", FriendRemoveListAndCreate.as_view(), name="friend-remove"),
     path("groups/", GroupList.as_view(), name="group-list"),
     path("groups/<int:pk>/", GroupDetail.as_view(), name="group-detail"),
+    path("groups/<int:pk>/add/", GroupDetailAdd.as_view(), name="group-detail-add"),
+    path("groups/<int:pk>/remove/", GroupDetailRemove.as_view(), name="group-detail-remove"),
     path("groups/<int:pk>/members/add/", GroupMembersAdd.as_view(), name="group-members-add"),
     path("groups/<int:pk>/members/remove/", GroupMembersRemove.as_view(), name="group-members-remove"),
     path("groups/<int:pk>/shows/add/", GroupShowsAdd.as_view(), name="group-shows-add"),

--- a/src/group/tasks.py
+++ b/src/group/tasks.py
@@ -1,18 +1,27 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
+from itertools import chain
 import json
+from random import sample
 from user.models import Profile
 
 from celery import shared_task
 from django.contrib.auth.models import User
+from django.core.cache import caches
 from group.models import Group
+from lst.models import Lst
 from notification.models import Notification
 from push_notifications.models import APNSDevice
 from push_notifications.models import GCMDevice
+from show.models import Show
+from show.show_api_utils import ShowAPI
+from show.tmdb import flicktmdb
 import tmdbsimple as tmdb
 from vote.models import Vote
 from vote.models import VoteType
+
+local_cache = caches["local"]
 
 
 @shared_task
@@ -79,3 +88,58 @@ def create_new_group_notif(profile_id, group_id, member_ids):
             android_devices.send_message(message={"title": "Telie", "body": message_body})
         except Exception:
             continue
+
+
+@shared_task
+def add_shows_to_group(user, group_id, show_ids, num_random_shows):
+    profile = user.profile
+    group = profile.groups.get(id=group_id)
+    api = flicktmdb()
+    for show_id in show_ids:
+        try:
+            show = Show.objects.get(id=show_id)
+            group.shows.add(show)
+        except:
+            continue
+    rec_shows = []
+    if num_random_shows > 0:
+        show_lst = []
+        lsts = Lst.objects.filter(is_private=False, owner__in=group.members.all()).prefetch_related("shows")
+        show_lst = [lst.shows.filter(ext_api_source="tmdb") for lst in lsts]
+        shows = list(chain.from_iterable(show_lst))
+        shows = sample(shows, min(5, len(shows)))
+        for show in group.shows.filter(ext_api_source="tmdb"):
+            shows.append(show)
+
+        for show in shows:
+            if not show:
+                continue
+            similar = local_cache.get((show.id, "similar"))
+            if not similar:
+                similar = api.get_similar_shows(show.ext_api_id, show.is_tv)
+                local_cache.set((show.id, "similar"), similar)
+            rec_shows.extend(similar)
+
+        if len(rec_shows) < num_random_shows:
+            rec_shows.extend(api.get_trending_shows())
+        data = ShowAPI.create_show_objects_no_serialization(rec_shows)
+        rec_shows = sample(data, num_random_shows)
+
+    for rec_show in rec_shows:
+        group.shows.add(rec_show)
+    group.save()
+
+    return
+
+
+@shared_task
+def remove_shows_from_group(user, group_id, show_ids):
+    group = user.profile.groups.get(id=group_id)
+    for show_id in show_ids:
+        try:
+            show = Show.objects.get(id=show_id)
+            group.shows.remove(show)
+        except:
+            continue
+    group.save()
+    return

--- a/src/group/tasks.py
+++ b/src/group/tasks.py
@@ -91,8 +91,8 @@ def create_new_group_notif(profile_id, group_id, member_ids):
 
 
 @shared_task
-def add_shows_to_group(user, group_id, show_ids, num_random_shows):
-    profile = user.profile
+def add_shows_to_group(user_id, group_id, show_ids, num_random_shows):
+    profile = Profile.objects.get(user__id=user_id)
     group = profile.groups.get(id=group_id)
     api = flicktmdb()
     for show_id in show_ids:
@@ -128,13 +128,13 @@ def add_shows_to_group(user, group_id, show_ids, num_random_shows):
     for rec_show in rec_shows:
         group.shows.add(rec_show)
     group.save()
-
     return
 
 
 @shared_task
-def remove_shows_from_group(user, group_id, show_ids):
-    group = user.profile.groups.get(id=group_id)
+def remove_shows_from_group(user_id, group_id, show_ids):
+    profile = Profile.objects.get(user__id=user_id)
+    group = profile.groups.get(id=group_id)
     for show_id in show_ids:
         try:
             show = Show.objects.get(id=show_id)

--- a/src/group/tests/test_groups.py
+++ b/src/group/tests/test_groups.py
@@ -50,19 +50,29 @@ class GroupTests(FlickTestCase):
 
     def _update_group(self, group_id=1, name="", members=[], shows=[], is_add=False, is_remove=False):
         if is_add:
-            url = reverse("group-detail-add", kwargs={"pk": group_id})
+            url_shows = reverse("group-shows-add", kwargs={"pk": group_id})
+            url_members = reverse("group-members-add", kwargs={"pk": group_id})
         elif is_remove:
-            url = reverse("group-detail-remove", kwargs={"pk": group_id})
+            url_shows = reverse("group-shows-remove", kwargs={"pk": group_id})
+            url_members = reverse("group-members-remove", kwargs={"pk": group_id})
         else:
             url = reverse("group-detail", kwargs={"pk": group_id})
         self.client.credentials(HTTP_AUTHORIZATION="Token " + self.user_token)
-        request_data = {
-            "name": name,
-            "members": members,
+        request_data_shows = {
             "shows": shows,
         }
-        response = self.client.post(url, request_data, format="json")
-        self.assertEqual(response.status_code, 200)
+        request_data_members = {
+            "members": members,
+        }
+        request_data = {"members": members, "shows": shows}
+        if is_add or is_remove:
+            response = self.client.post(url_members, request_data_shows, format="json")
+            self.assertEqual(response.status_code, 200)
+            response = self.client.post(url_shows, request_data_members, format="json")
+            self.assertEqual(response.status_code, 200)
+        else:
+            response = self.client.post(url, request_data, format="json")
+
         data = json.loads(response.content)["data"]
         return data
 

--- a/src/group/views.py
+++ b/src/group/views.py
@@ -1,27 +1,24 @@
 import datetime
-from itertools import chain
 import json
-from random import sample
 from user.models import Profile
 
 from api import settings as api_settings
 from api.utils import success_response
 from django.core.cache import caches
-from lst.models import Lst
 import pytz
 from rest_framework import generics
-from show.models import Show
 from show.serializers import GroupShowSerializer
 from show.serializers import ShowSerializer
-from show.show_api_utils import ShowAPI
 from show.tmdb import flicktmdb
 from vote.serializers import VoteSerializer
 
 from .models import Group
 from .serializers import GroupSerializer
 from .serializers import GroupSimpleSerializer
+from .tasks import add_shows_to_group
 from .tasks import clear_shows
 from .tasks import create_new_group_notif
+from .tasks import remove_shows_from_group
 from .tasks import vote
 
 local_cache = caches["local"]
@@ -85,7 +82,20 @@ class GroupDetail(generics.GenericAPIView):
         return success_response(serializer.data)
 
 
-class GroupDetailAdd(generics.GenericAPIView):
+class GroupShowsAdd(generics.GenericAPIView):
+    serializer_class = GroupSerializer
+    permission_classes = api_settings.CONSUMER_PERMISSIONS
+    api = flicktmdb()
+
+    def post(self, request, pk):
+        data = json.loads(request.body)
+        show_ids = data.get("shows", [])
+        num_random_shows = data.get("num_random_shows", 0)
+        add_shows_to_group(request.user, pk, show_ids, num_random_shows)
+        return success_response()
+
+
+class GroupMembersAdd(generics.GenericAPIView):
     serializer_class = GroupSerializer
     permission_classes = api_settings.CONSUMER_PERMISSIONS
     api = flicktmdb()
@@ -96,47 +106,12 @@ class GroupDetailAdd(generics.GenericAPIView):
         group = profile.groups.get(id=pk)
         data = json.loads(request.body)
         member_ids = data.get("members", [])
-        show_ids = data.get("shows", [])
-        num_random_shows = data.get("num_random_shows", 0)
         for member_id in member_ids:
             try:
                 member_profile = Profile.objects.get(user__id=member_id)
                 group.members.add(member_profile)
             except:
                 continue
-        for show_id in show_ids:
-            try:
-                show = Show.objects.get(id=show_id)
-                group.shows.add(show)
-            except:
-                continue
-        rec_shows = []
-        if num_random_shows > 0:
-            show_lst = []
-            lsts = Lst.objects.filter(is_private=False, owner__in=group.members.all())
-            show_lst = [lst.shows.filter(ext_api_source="tmdb") for lst in lsts]
-            shows = list(chain.from_iterable(show_lst))
-            shows = sample(shows, min(5, len(shows)))
-            for show in group.shows.filter(ext_api_source="tmdb"):
-                shows.append(show)
-
-            for show in shows:
-                if not show:
-                    continue
-                similar = local_cache.get((show.id, "similar"))
-                if not similar:
-                    similar = self.api.get_similar_shows(show.ext_api_id, show.is_tv)
-                    local_cache.set((show.id, "similar"), similar)
-                rec_shows.extend(similar)
-
-            if len(rec_shows) < num_random_shows:
-                rec_shows.extend(self.api.get_trending_shows())
-
-            data = ShowAPI.create_show_objects_no_serialization(rec_shows)
-            rec_shows = sample(data, num_random_shows)
-
-        for rec_show in rec_shows:
-            group.shows.add(rec_show)
         group.save()
 
         create_new_group_notif.delay(profile_id=profile.id, group_id=group.id, member_ids=member_ids)
@@ -144,7 +119,7 @@ class GroupDetailAdd(generics.GenericAPIView):
         return success_response(serializer.data)
 
 
-class GroupDetailRemove(generics.GenericAPIView):
+class GroupMembersRemove(generics.GenericAPIView):
     serializer_class = GroupSerializer
     permission_classes = api_settings.CONSUMER_PERMISSIONS
 
@@ -154,22 +129,26 @@ class GroupDetailRemove(generics.GenericAPIView):
         group = profile.groups.get(id=pk)
         data = json.loads(request.body)
         member_ids = data.get("members", [])
-        show_ids = data.get("shows", [])
         for member_id in member_ids:
             try:
                 member_profile = Profile.objects.get(user__id=member_id)
                 group.members.remove(member_profile)
             except:
                 continue
-        for show_id in show_ids:
-            try:
-                show = Show.objects.get(id=show_id)
-                group.shows.remove(show)
-            except:
-                continue
         group.save()
         serializer = self.serializer_class(group)
         return success_response(serializer.data)
+
+
+class GroupShowsRemove(generics.GenericAPIView):
+    permission_classes = api_settings.CONSUMER_PERMISSIONS
+
+    def post(self, request, pk):
+        """Update a group by id by removing members and shows."""
+        data = json.loads(request.body)
+        show_ids = data.get("shows", [])
+        remove_shows_from_group(request.user, pk, show_ids)
+        return success_response()
 
 
 class GroupClearShows(generics.GenericAPIView):

--- a/src/group/views.py
+++ b/src/group/views.py
@@ -101,6 +101,17 @@ class GroupShowsAdd(generics.GenericAPIView):
         return success_response()
 
 
+class GroupShowsRemove(generics.GenericAPIView):
+    permission_classes = api_settings.CONSUMER_PERMISSIONS
+
+    def post(self, request, pk):
+        """Update a group by id by removing shows."""
+        data = json.loads(request.body)
+        show_ids = data.get("shows", [])
+        remove_shows_from_group.delay(user_id=request.user.id, group_id=pk, show_ids=show_ids)
+        return success_response()
+
+
 class GroupMembersAdd(generics.GenericAPIView):
     serializer_class = GroupSimpleSerializer
     permission_classes = api_settings.CONSUMER_PERMISSIONS
@@ -144,17 +155,6 @@ class GroupMembersRemove(generics.GenericAPIView):
         group.save()
         serializer = self.serializer_class(group)
         return success_response(serializer.data)
-
-
-class GroupShowsRemove(generics.GenericAPIView):
-    permission_classes = api_settings.CONSUMER_PERMISSIONS
-
-    def post(self, request, pk):
-        """Update a group by id by removing shows."""
-        data = json.loads(request.body)
-        show_ids = data.get("shows", [])
-        remove_shows_from_group.delay(user_id=request.user.id, group_id=pk, show_ids=show_ids)
-        return success_response()
 
 
 class GroupDetailAdd(generics.GenericAPIView):

--- a/src/group/views.py
+++ b/src/group/views.py
@@ -88,20 +88,21 @@ class GroupShowsAdd(generics.GenericAPIView):
     api = flicktmdb()
 
     def post(self, request, pk):
+        """Update a group by id by adding shows"""
         data = json.loads(request.body)
         show_ids = data.get("shows", [])
         num_random_shows = data.get("num_random_shows", 0)
-        add_shows_to_group(request.user, pk, show_ids, num_random_shows)
+        add_shows_to_group.delay(request.user.id, pk, show_ids, num_random_shows)
         return success_response()
 
 
 class GroupMembersAdd(generics.GenericAPIView):
-    serializer_class = GroupSerializer
+    serializer_class = GroupSimpleSerializer
     permission_classes = api_settings.CONSUMER_PERMISSIONS
     api = flicktmdb()
 
     def post(self, request, pk):
-        """Update a group by id by adding members and shows."""
+        """Update a group by id by adding members"""
         profile = Profile.objects.get(user=request.user)
         group = profile.groups.get(id=pk)
         data = json.loads(request.body)
@@ -120,11 +121,11 @@ class GroupMembersAdd(generics.GenericAPIView):
 
 
 class GroupMembersRemove(generics.GenericAPIView):
-    serializer_class = GroupSerializer
+    serializer_class = GroupSimpleSerializer
     permission_classes = api_settings.CONSUMER_PERMISSIONS
 
     def post(self, request, pk):
-        """Update a group by id by removing members and shows."""
+        """Update a group by id by removing members."""
         profile = Profile.objects.get(user=request.user)
         group = profile.groups.get(id=pk)
         data = json.loads(request.body)
@@ -144,10 +145,10 @@ class GroupShowsRemove(generics.GenericAPIView):
     permission_classes = api_settings.CONSUMER_PERMISSIONS
 
     def post(self, request, pk):
-        """Update a group by id by removing members and shows."""
+        """Update a group by id by removing shows."""
         data = json.loads(request.body)
         show_ids = data.get("shows", [])
-        remove_shows_from_group(request.user, pk, show_ids)
+        remove_shows_from_group.delay(user_id=request.user.id, group_id=pk, show_ids=show_ids)
         return success_response()
 
 


### PR DESCRIPTION
## Overview
separated out the endpoint to add shows.
now there are 2 endpoints to each to add to /remove from a group

add members `/api/groups/<pk>/members/add/`
add shows `/api/groups/<pk>/shows/add/`
Remove members `/api/groups/<pk>/members/remove/`
Remove shows `/api/groups/<pk>/shows/remove/`

Sample post body for add/remove
```
{
    "members": [1, 2]
}
```
```
{
    "shows": [1]
}
```
Sample response body for adding/removing member:
```
{
    "success": true,
    "data": {
        "id": 2,
        "name": "group name",
        "members": [
            {
                "id": 2,
                "username": "test",
                "name": "test",
                "profile_pic": ""
            }
        ],
        "shows": [
            {
                "id": 2,
                "ext_api_id": 2304,
                "ext_api_source": "tmdb",
                "title": "Thomas & Friends",
                "poster_pic": "http://image.tmdb.org/t/p/w400/ovJvWQ8E8aYShcRlTwpqKhuq7FA.jpg",
                "backdrop_pic": "http://image.tmdb.org/t/p/w400/wIe1HL7oMNwyltsqqx2sCPwNl4w.jpg",
                "is_tv": true,
                "is_adult": null,
                "plot": "Thomas & Friends is a British children's television series, which had its first broadcast on the ITV network on 4 September 1984. It is based on The Railway Series of books by the Reverend Wilbert Awdry and his son, Christopher Awdry. These books deal with the adventures of a group of anthropomorphised locomotives and road vehicles who live on the fictional Island of Sodor. The books were based on stories Wilbert told to entertain his son, Christopher during his recovery from measles. From Series one to four, many of the stories are based on events from Awdry's personal experience.",
                "date_released": "1984-10-09",
                "language": "en"
            }
        ]
    }
}
```
add/remove shows is async, thus does not return any data.
sample response body
```
{
    "success": true
}
```

## Changes Made
split the `groups/<pk>/add` into `/api/groups/<pk>/members/add/` and `/api/groups/<pk>/shows/add/`
split the `groups/<pk>/remove` into `/api/groups/<pk>/members/remove/` and `/api/groups/<pk>/shows/remove/`

## Test Coverage
tested manually on the postman.
There seems to be something wrong with the group tests (It doesn't pass on master either) and are labeled as flakey

## Next Steps
fix the group test cases


## Related PRs or Issues
#292 

