### PR TITLE
separate endpoint for adding/removing movies to/from lists

### DIFF
--- a/src/api/urls.py
+++ b/src/api/urls.py
@@ -38,6 +38,8 @@ from lst.views import LstDetail
 from lst.views import LstDetailAdd
 from lst.views import LstDetailRemove
 from lst.views import LstList
+from lst.views import LstShowsAdd
+from lst.views import LstShowsRemove
 from notification.views import NotificationEnable
 from notification.views import NotificationList
 from notification.views import NotificationTest
@@ -91,8 +93,10 @@ urlpatterns = [
     path("lsts/", LstList.as_view(), name="lst-list"),
     path("lsts/<int:pk>/", LstDetail.as_view(), name="lst-detail"),
     path("lsts/<int:pk>/add/", LstDetailAdd.as_view(), name="lst-detail-add"),
+    path("lsts/<int:pk>/shows/add/", LstShowsAdd.as_view(), name="lst-shows-add"),
     path("lsts/<int:pk>/recommend/", LstRecommendView.as_view(), name="lst-recommend"),
     path("lsts/<int:pk>/remove/", LstDetailRemove.as_view(), name="lst-detail-remove"),
+    path("lsts/<int:pk>/shows/remove/", LstShowsRemove.as_view(), name="lst-shows-remove"),
     path("lsts/<int:pk>/like/", LstLikeView.as_view(), name="like-list"),
     path("me/", UserView.as_view(), name="me"),
     path("media/image/", UploadImage.as_view(), name="upload"),

--- a/src/lst/tasks.py
+++ b/src/lst/tasks.py
@@ -123,7 +123,6 @@ def modify_lst_shows(user_id, lst_id, show_ids, is_add, is_remove):
     if not is_owner and not is_collaborator:
         return
     for show in Show.objects.filter(id__in=show_ids).prefetch_related("activity"):
-
         if is_add:
             if lst.shows.filter(id=show.id).exists():
                 return

--- a/src/lst/views.py
+++ b/src/lst/views.py
@@ -12,6 +12,7 @@ from .controllers.delete_lst_controller import DeleteLstController
 from .controllers.update_lst_controller import UpdateLstController
 from .models import Lst
 from .serializers import LstWithSimpleShowsSerializer
+from .tasks import modify_lst_shows
 
 
 class LstList(generics.GenericAPIView):
@@ -96,6 +97,34 @@ class LstDetailAdd(generics.GenericAPIView):
         return UpdateLstController(
             request=request, pk=pk, data=data, serializer=self.serializer_class, is_add=True, is_remove=False
         ).process()
+
+
+class LstShowsAdd(generics.GenericAPIView):
+
+    permission_classes = api_settings.CONSUMER_PERMISSIONS
+
+    def post(self, request, pk):
+        """
+        add shows to a list
+        """
+        data = json.loads(request.body)
+        show_ids = data.get("shows", [])
+        modify_lst_shows.delay(request.user.id, pk, show_ids, is_add=True, is_remove=False)
+        return success_response()
+
+
+class LstShowsRemove(generics.GenericAPIView):
+
+    permission_classes = api_settings.CONSUMER_PERMISSIONS
+
+    def post(self, request, pk):
+        """
+        remove shows from a list
+        """
+        data = json.loads(request.body)
+        show_ids = data.get("shows", [])
+        modify_lst_shows.delay(request.user.id, pk, show_ids, is_add=False, is_remove=True)
+        return success_response()
 
 
 class LstDetailRemove(generics.GenericAPIView):

--- a/src/lst/views.py
+++ b/src/lst/views.py
@@ -105,7 +105,7 @@ class LstShowsAdd(generics.GenericAPIView):
 
     def post(self, request, pk):
         """
-        Add shows to a list
+        Add shows to a list.
         """
         data = json.loads(request.body)
         show_ids = data.get("shows", [])
@@ -119,7 +119,7 @@ class LstShowsRemove(generics.GenericAPIView):
 
     def post(self, request, pk):
         """
-        Remove shows from a list
+        Remove shows from a list.
         """
         data = json.loads(request.body)
         show_ids = data.get("shows", [])

--- a/src/lst/views.py
+++ b/src/lst/views.py
@@ -105,7 +105,7 @@ class LstShowsAdd(generics.GenericAPIView):
 
     def post(self, request, pk):
         """
-        add shows to a list
+        Add shows to a list
         """
         data = json.loads(request.body)
         show_ids = data.get("shows", [])
@@ -119,7 +119,7 @@ class LstShowsRemove(generics.GenericAPIView):
 
     def post(self, request, pk):
         """
-        remove shows from a list
+        Remove shows from a list
         """
         data = json.loads(request.body)
         show_ids = data.get("shows", [])


### PR DESCRIPTION
## Overview
added 2 async endpoints for adding movies to lists and removing movies from lists
`api/lsts/<pk>/shows/add/` and 
`api/lsts/<pk>/shows/remove/`
It increases the server performance when a lot of shows need to be added to a list.

## Changes Made
In addition to the original list update endpoint, I added new endpoints to support adding only movies into/ removing movies from lists.
other list modifications should still go through the original endpoint
sample post body 
```
{
 "shows":[1, 2, 10]
}
```
sample response
```
{
    "success": true
}
```

## Test Coverage
tested manually on postman
