### PR TITLE
Remove AWS S3 image object when user removes profile picture

### DIFF
--- a/src/user/models.py
+++ b/src/user/models.py
@@ -1,4 +1,6 @@
 from asset.models import AssetBundle
+import boto3
+from django.conf import settings
 from django.contrib.auth.models import User
 from django.db import models
 from django.db.models import Q
@@ -40,6 +42,10 @@ class Profile(models.Model):
         return unviewed_notifs.count() + unviewed_suggests.count()
 
     def remove_profile_pic(self):
+        if self.profile_pic_url:
+            s3 = boto3.resource("s3")
+            key = self.profile_pic_url.split("image/")[1]
+            s3.Object(settings.S3_BUCKET, f"image/{key}").delete()
         self.profile_pic = ""
         self.profile_pic_url = ""
         super(Profile, self).save()


### PR DESCRIPTION
## Overview
We should actually remove hosting from s3 once a user removes a profile pic

## Test Coverage
I'm not actually sure this works lol but i'll test it once it gets deployed uwu


## Related PRs or Issues
Closes #328

