### PR TITLE
Vivi/delete reactions

### DIFF
--- a/src/api/urls.py
+++ b/src/api/urls.py
@@ -44,6 +44,7 @@ from notification.views import NotificationEnable
 from notification.views import NotificationList
 from notification.views import NotificationTest
 from reaction.views import ReactionAdd
+from reaction.views import ReactionDelete
 from read.views import ReadView
 from recommend.views import LstRecommendView
 from rest_framework import routers
@@ -102,6 +103,7 @@ urlpatterns = [
     path("me/", UserView.as_view(), name="me"),
     path("media/image/", UploadImage.as_view(), name="upload"),
     path("reactions/add/", ReactionAdd.as_view(), name="add-reaction"),
+    path("reactions/<int:pk>/delete/", ReactionDelete.as_view(), name="delete-reaction"),
     path("search/", Search.as_view(), name="search"),
     path("show/<int:pk>/", ShowDetail.as_view(), name="show-detail"),
     path("show/<int:pk>/lsts/add/", AddShowToListsView.as_view(), name="add-show-to-list"),

--- a/src/reaction/views.py
+++ b/src/reaction/views.py
@@ -40,9 +40,6 @@ class ReactionAdd(generics.GenericAPIView):
 
 class ReactionDelete(generics.GenericAPIView):
 
-    queryset = Reaction.objects.all()
-    serializer_class = ReactionSerializer
-
     permission_classes = api_settings.CONSUMER_PERMISSIONS
 
     def post(self, request, pk):

--- a/src/reaction/views.py
+++ b/src/reaction/views.py
@@ -36,3 +36,24 @@ class ReactionAdd(generics.GenericAPIView):
         reaction.save()
         serializer = self.serializer_class(reaction)
         return success_response(serializer.data)
+
+
+class ReactionDelete(generics.GenericAPIView):
+
+    queryset = Reaction.objects.all()
+    serializer_class = ReactionSerializer
+
+    permission_classes = api_settings.CONSUMER_PERMISSIONS
+
+    def post(self, request, pk):
+        """
+        Delete a reaction
+        """
+        profile = Profile.objects.get(user=request.user)
+        if not Reaction.objects.filter(id=pk).exists():
+            return failure_response(f"Reaction with id {pk} does not exist!")
+        reaction = Reaction.objects.get(id=pk)
+        if not reaction.author == profile:
+            return failure_response(f"User {profile.id} is not authorized to delete reaction {pk}!")
+        reaction.delete()
+        return success_response()


### PR DESCRIPTION
## Overview

Add endpoint for deleting a reaction

## Test Coverage

requests work on postman but need to add test cases later :')

## Related PRs or Issues

closes #369 


## Example
POST `http://127.0.0.1:8000/api/reactions/3/delete/`

successful response
```
{"success": true }
```
failure responses
- user is not reaction author 
```
{
    "success": false,
    "error": "User 2 is not authorized to delete reaction 3!"
}
```

- reaction doesn't exist
```
{
    "success": false,
    "error": "Reaction with id 10 does not exist!"
}
```
