### PR TITLE
Add season num field for season detail

### DIFF
--- a/src/season_detail/serializers.py
+++ b/src/season_detail/serializers.py
@@ -17,5 +17,5 @@ class SeasonDetailShortenedEpisodeDetailsSerializer(serializers.ModelSerializer)
 
     class Meta:
         model = SeasonDetail
-        fields = ("id", "episode_details")
+        fields = ("id", "season_num", "episode_details")
         read_only_fields = fields


### PR DESCRIPTION
## Overview
Add `season_num` field to `season_details` for `api/show/<pk>/reactions/`
Note: this endpoint does not repopulate the show episode details, so it might be empty `"season_details": []`

## Related PRs or Issues
followup to #378 

## Response
```
{
    "success": true,
    "data": {
        "id": 400,
        "season_details": [
            {
                "id": 172,
                "season_num": 1,
                "episode_details": [
                    {
                        "id": 3848,
                        "ext_api_id": 1575560,
                        "episode_num": 1,
                        "name": "The Secret of the Gold Medal",
                        "overview": "The Golden Medal that has the key to unlocking the secrets of the Mayan Civilization was stolen by Lord Zero! Professor Gilt sends Montana and Alfred to the ruins of the ancient Mayan Civilization in order to reclaim it. On the way they meet Melissa, a diplomat's daughter in the city of Merida. They head into a pyramid. What was waiting there?",
                        "reactions": [],
                        "is_default": false
                    }, {...}
                 ]
             ]
         }
     } 
```